### PR TITLE
Fix timeouts for login node startup scripts

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -591,6 +591,7 @@ def install_custom_scripts(clean=False):
 def run_custom_scripts():
     """run custom scripts based on instance_role"""
     custom_dir = dirs.custom_scripts
+    suffix = instance_metadata("attributes/slurm_login_suffix")
     if lkp.instance_role == "controller":
         # controller has all scripts, but only runs controller.d
         custom_dirs = [custom_dir / "controller.d"]
@@ -599,7 +600,6 @@ def run_custom_scripts():
         custom_dirs = [custom_dir / "compute.d", custom_dir / "partition.d"]
     elif lkp.instance_role == "login":
         # login setup with only login_{suffix}.d
-        suffix = instance_metadata("attributes/slurm_login_suffix")
         custom_dirs = [custom_dir / f"login_{suffix}.d"]
     else:
         # Unknown role: run nothing
@@ -620,6 +620,8 @@ def run_custom_scripts():
             elif "/compute.d/" in str(script):
                 timeout = lkp.cfg.get("compute_startup_scripts_timeout", 300)
             elif "/login.d/" in str(script):
+                timeout = lkp.cfg.get("login_startup_scripts_timeout", 300)
+            elif f"/login_{suffix}.d/" in str(script):
                 timeout = lkp.cfg.get("login_startup_scripts_timeout", 300)
             elif "/partition.d/" in str(script):
                 partition_name = lkp.node_partition_name()

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -591,7 +591,7 @@ def install_custom_scripts(clean=False):
 def run_custom_scripts():
     """run custom scripts based on instance_role"""
     custom_dir = dirs.custom_scripts
-    suffix = instance_metadata("attributes/slurm_login_suffix")
+    suffix = None
     if lkp.instance_role == "controller":
         # controller has all scripts, but only runs controller.d
         custom_dirs = [custom_dir / "controller.d"]
@@ -600,6 +600,7 @@ def run_custom_scripts():
         custom_dirs = [custom_dir / "compute.d", custom_dir / "partition.d"]
     elif lkp.instance_role == "login":
         # login setup with only login_{suffix}.d
+        suffix = instance_metadata("attributes/slurm_login_suffix")
         custom_dirs = [custom_dir / f"login_{suffix}.d"]
     else:
         # Unknown role: run nothing
@@ -619,9 +620,8 @@ def run_custom_scripts():
                 timeout = lkp.cfg.get("controller_startup_scripts_timeout", 300)
             elif "/compute.d/" in str(script):
                 timeout = lkp.cfg.get("compute_startup_scripts_timeout", 300)
-            elif "/login.d/" in str(script):
-                timeout = lkp.cfg.get("login_startup_scripts_timeout", 300)
-            elif f"/login_{suffix}.d/" in str(script):
+            elif "/login.d/" in str(script) or \
+                 (suffix is not None and f"/login_{suffix}.d/" in str(script)):
                 timeout = lkp.cfg.get("login_startup_scripts_timeout", 300)
             elif "/partition.d/" in str(script):
                 partition_name = lkp.node_partition_name()


### PR DESCRIPTION
There is an issue where the timeout isn't working for the login nodes.  This is due to the fact that the login node startup scripts may be placed in a folder that follows a format like `/slurm/custom_scripts/login_{suffix}.d/...`.  The current check for timeouts only looks for `login.d` which does not match.

This fix simply adds another check for the login with the suffix and uses the same timeout.

This fix has been tested a few ways (below).  Each test has `login_startup_scripts_timeout` set to 1000 and a login startup script that slept for 400s (beyond the default 300).

1. Bring up a simple cluster with a login node, update `setup.py` with the code here and run.  The new timeout was respected correctly.
2. Bring up the same cluster without a login node.  `setup.py` was updated again on the controller node, and the default timeout condition in `setup.py` was tested as it would exercise whether or not the suffix change would break anything.  It did not.

Until, this is put into a new image release, the HPC Toolkit is being updated to disallow users from updating `login_startup_scripts_timeout` as it isn't respected.