### PR TITLE
Install legacy stackdriver by default instead of ops agent for improved performance

### DIFF
--- a/ansible/roles/cloudagents/defaults/main.yaml
+++ b/ansible/roles/cloudagents/defaults/main.yaml
@@ -1,0 +1,4 @@
+---
+# options are 'cloud-ops' or 'legacy' or 'none'
+# 'legacy' = stackdriver
+monitoring_agent: legacy

--- a/ansible/roles/cloudagents/meta/main.yml
+++ b/ansible/roles/cloudagents/meta/main.yml
@@ -15,7 +15,18 @@
 
 dependencies:
 - role: common
+
 - role: google_cloud_ops_agents
   vars:
     agent_type: ops-agent
-    package_state: present
+  when: monitoring_agent == "cloud-ops"
+
+- role: google_cloud_ops_agents
+  vars:
+    agent_type: monitoring
+  when: monitoring_agent == "legacy"
+
+- role: google_cloud_ops_agents
+  vars:
+    agent_type: logging
+  when: monitoring_agent == "legacy"

--- a/ansible/roles/cloudagents/tasks/main.yml
+++ b/ansible/roles/cloudagents/tasks/main.yml
@@ -17,3 +17,16 @@
   template:
     src: ops_agent.yaml.j2
     dest: /etc/google-cloud-ops-agent/config.yaml
+  when: monitoring_agent == "cloud-ops"
+
+- name: Install 'stackdriver' Config For Slurm Daemon Logs
+  template:
+    src: legacy_agent_daemon_log.conf.j2
+    dest: /etc/google-fluentd/config.d/slurm_daemon.conf
+  when: monitoring_agent == "legacy"
+
+- name: Install 'stackdriver' Config For Slurm Python Script Logs
+  template:
+    src: legacy_agent_py_script_log.conf.j2
+    dest: /etc/google-fluentd/config.d/slurm_py_script.conf
+  when: monitoring_agent == "legacy"

--- a/ansible/roles/cloudagents/templates/legacy_agent_daemon_log.conf.j2
+++ b/ansible/roles/cloudagents/templates/legacy_agent_daemon_log.conf.j2
@@ -1,0 +1,8 @@
+<source>
+  @type tail
+  format /^\[(?<time>\S+)\] (?<message>((?<severity>(fatal|error|verbose|debug[0-9]?)):)?.*)$/
+  path /var/log/slurm/slurmdbd.log,/var/log/slurm/slurmrestd.log,/var/log/slurm/slurmctld.log,/var/log/slurm/slurmd-*.log
+  pos_file /var/lib/google-fluentd/pos/slurm_daemon.pos
+  read_from_head true
+  tag slurm
+</source>

--- a/ansible/roles/cloudagents/templates/legacy_agent_py_script_log.conf.j2
+++ b/ansible/roles/cloudagents/templates/legacy_agent_py_script_log.conf.j2
@@ -1,0 +1,8 @@
+<source>
+  @type tail
+  format /^(?<time>\S+ \S+) (?<message>(?<severity>(CRITICAL|ERROR|WARNING|INFO|DEBUG))(\(\S+\))?:.*)$/
+  path /var/log/slurm/resume.log,/var/log/slurm/suspend.log,/var/log/slurm/slurmsync.log,/slurm/scripts/setup.log
+  pos_file /var/lib/google-fluentd/pos/slurm_py_script.pos
+  read_from_head true
+  tag slurm
+</source>


### PR DESCRIPTION
Patching V5 with #18.

Tested: Built Slurm image from Rocky8 and deployed v5 cluster using this patch.