### PR TITLE
Correcting Wrong Module

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -407,7 +407,7 @@ def install_slurmdbd_conf(lkp):
     )
     if lkp.cfg.cloudsql:
         secret_name = f"{cfg.slurm_cluster_name}-slurm-secret-cloudsql"
-        payload = json.loads(access_secret_version(util.project, secret_name))
+        payload = json.loads(access_secret_version(lkp.project, secret_name))
 
         if payload["db_name"] and payload["db_name"] != "":
             conf_options.db_name = payload["db_name"]


### PR DESCRIPTION
This request changes the module used from `util` to `lkp`.

Since `util` does not have the attribute `project`, an Attribute error comes up when deploying a blueprint that uses CloudSQL.

Prior to the change:
The controller would fail and /slurm/scripts/setup.log would show the following error.
```
2024-01-17 20:59:36,700 DEBUG: get_metadata: metadata not found (http://metadata.google.internal/computeMetadata/v1/project/attributes/hpccluster-slurm-devel)
2024-01-17 20:59:36,700 DEBUG: fetch_devel_scripts: scripts not found in project metadata, devel mode not enabled
2024-01-17 20:59:36,703 INFO: Setting up controller
2024-01-17 20:59:36,705 INFO: installing custom scripts: compute.d/ghpc_startup.sh,controller.d/ghpc_startup.sh,login_4jj16xwq.d/ghpc_startup.sh,partition.d/compute/ghpc_startup.sh
2024-01-17 20:59:36,705 DEBUG: install_custom_scripts: compute.d/ghpc_startup.sh
2024-01-17 20:59:36,708 DEBUG: install_custom_scripts: controller.d/ghpc_startup.sh
2024-01-17 20:59:36,710 DEBUG: install_custom_scripts: login_4jj16xwq.d/ghpc_startup.sh
2024-01-17 20:59:36,713 DEBUG: install_custom_scripts: partition.d/compute/ghpc_startup.sh
2024-01-17 20:59:36,717 ERROR: module 'util' has no attribute 'project'
Traceback (most recent call last):
  File "/slurm/scripts/setup.py", line 1275, in <module>
    main(args)
  File "/slurm/scripts/setup.py", line 1251, in main
    setup(args)
  File "/slurm/scripts/setup.py", line 1090, in setup_controller
    install_slurmdbd_conf(lkp)
  File "/slurm/scripts/setup.py", line 410, in install_slurmdbd_conf
    payload = json.loads(access_secret_version(util.project, secret_name))
AttributeError: module 'util' has no attribute 'project'
2024-01-17 20:59:36,717 ERROR: Aborting setup...
```


After the making the change locally:
Running setup.py allows the controller to be setup and the following is added to /slurm/scripts/setup.log
```
2024-01-24 03:24:24,643 DEBUG: get_metadata: metadata not found (http://metadata.google.internal/computeMetadata/v1/project/attributes/cluster5-slurm-devel)
2024-01-24 03:24:24,644 DEBUG: fetch_devel_scripts: scripts not found in project metadata, devel mode not enabled
2024-01-24 03:24:24,646 INFO: Setting up controller
2024-01-24 03:24:24,649 INFO: installing custom scripts: compute.d/ghpc_startup.sh,controller.d/ghpc_startup.sh
2024-01-24 03:24:24,649 DEBUG: install_custom_scripts: compute.d/ghpc_startup.sh
2024-01-24 03:24:24,651 DEBUG: install_custom_scripts: controller.d/ghpc_startup.sh
2024-01-24 03:24:24,962 DEBUG: __call__: Making request: GET http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/?recursive=true
2024-01-24 03:24:24,965 DEBUG: __call__: Making request: GET http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/305502790899-compute@developer.gserviceaccount.com/token?scopes=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcloud-platform
2024-01-24 03:24:25,003 DEBUG: access_secret_version: Secret 'projects/dev-pool-prj3/secrets/cluster5-slurm-secret-cloudsql/versions/latest' was found.
2024-01-24 03:24:25,006 DEBUG: compute_service: Using version=v1 of Google Compute Engine API
2024-01-24 03:25:00,496 INFO: Set up network storage
2024-01-24 03:25:00,497 INFO: Setting up mount (nfs) 10.0.0.2:/exports/data to /data
2024-01-24 03:25:00,573 INFO: Waiting for '/data' to be mounted...
2024-01-24 03:25:00,745 INFO: Mount point '/data' was mounted.
2024-01-24 03:25:00,747 DEBUG: run_custom_scripts: custom scripts to run: /slurm/custom_scripts/(controller.d/ghpc_startup.sh)
2024-01-24 03:25:00,747 INFO: running script ghpc_startup.sh with timeout=300
2024-01-24 03:25:00,751 INFO: ghpc_startup.sh returncode=0
stdout=stderr=
2024-01-24 03:25:06,963 INFO: Check status of cluster services
2024-01-24 03:25:09,275 INFO: Done setting up controller

```