### PR TITLE
Update regex to properly capture slurm node status

### DIFF
--- a/scripts/util.py
+++ b/scripts/util.py
@@ -1540,7 +1540,7 @@ class Lookup:
 
         cmd = (
             f"{self.scontrol} show nodes | "
-            r"grep -oP '^NodeName=\K(\S+)|State=\K(\S+)' | "
+            r"grep -oP '^NodeName=\K(\S+)|\s+State=\K(\S+)' | "
             r"paste -sd',\n'"
         )
         node_lines = run(cmd, shell=True).stdout.rstrip().splitlines()


### PR DESCRIPTION
After issuing "scontrol reboot ASAP nodename", the output of "scontrol show nodes" includes more fields than is supported by the current regular expression used to filter the output. This PR reduces the greediness of the regular expression to account for this.

Resolves GoogleCloudPlatform/hpc-toolkit#2139

(cherry picked from commit 3fe5b94d1bacdc5e5c52a18600ec553563f32375)