### PR TITLE
Fix Typos For CloudSQL v6

### DIFF
--- a/scripts/conf.py
+++ b/scripts/conf.py
@@ -348,9 +348,9 @@ def install_slurmdbd_conf(lkp=lkp):
             "db_port": "3306",
         }
     )
-    if lkp.cfg.cloudsql:
+    if lkp.cfg.cloudsql_secret:
         secret_name = f"{cfg.slurm_cluster_name}-slurm-secret-cloudsql"
-        payload = json.loads(access_secret_version(util.project, secret_name))
+        payload = json.loads(access_secret_version(lkp.project, secret_name))
 
         if payload["db_name"] and payload["db_name"] != "":
             conf_options.db_name = payload["db_name"]


### PR DESCRIPTION
When deploying a blueprint using CloudSQL on v6, the controller would fail to set up with the following error.

```
2024-01-19 22:23:33,307 INFO: Check status of cluster services
2024-01-19 22:23:33,351 ERROR: CalledProcessError:
    command=['systemctl', 'status', 'slurmctld']
    returncode=3
    stdout:
● slurmctld.service - Slurm controller daemon
   Loaded: loaded (/usr/lib/systemd/system/slurmctld.service; enabled; vendor preset: disabled)
   Active: failed (Result: exit-code) since Fri 2024-01-19 22:23:33 UTC; 172ms ago
 Main PID: 1746 (code=exited, status=1/FAILURE)

Jan 19 22:23:32 hpccluster-controller systemd[1]: Started Slurm controller daemon.
Jan 19 22:23:33 hpccluster-controller slurmctld[1746]: slurmctld: slurmctld version 23.02.4 started on cluster hpccluster
Jan 19 22:23:33 hpccluster-controller slurmctld[1746]: slurmctld: error: slurm_persist_conn_open_without_init: failed to open persistent connection to host:hpccluster-controller:6819: Connection refused
Jan 19 22:23:33 hpccluster-controller slurmctld[1746]: slurmctld: error: Sending PersistInit msg: Connection refused
Jan 19 22:23:33 hpccluster-controller slurmctld[1746]: slurmctld: accounting_storage/slurmdbd: clusteracct_storage_p_register_ctld: Registering slurmctld at port 6820 with slurmdbd
Jan 19 22:23:33 hpccluster-controller slurmctld[1746]: slurmctld: error: Sending PersistInit msg: Connection refused
Jan 19 22:23:33 hpccluster-controller slurmctld[1746]: slurmctld: fatal: You are running with a database but for some reason we have no TRES from it.  This should only happen if the database is down and you don't have any state files.
Jan 19 22:23:33 hpccluster-controller systemd[1]: slurmctld.service: Main process exited, code=exited, status=1/FAILURE
Jan 19 22:23:33 hpccluster-controller systemd[1]: slurmctld.service: Failed with result 'exit-code'.
    stderr:


2024-01-19 22:23:33,351 ERROR: Aborting setup...

```
When checking the slurmdbd.conf file, we would expect to see StorageHost connected to the CloudSQL's private IP, but instead it is connected to localhost.

```
StorageType=accounting_storage/mysql
StorageHost=localhost
StoragePort=3306
StorageUser=slurm
StoragePass=""
```

The changes made allow the controller to properly connect to the CloudSQL instance's private IP and set up the controller. After making the changes locally, the following is added to the setup logs.

```
*** Slurm is currently being configured in the background. ***
                                                                               
INFO: Setting up controller
INFO: installing custom script: controller.d/ghpc_startup.sh from hpccluster-files/slurm-controller-script-ghpc_startup_sh
DEBUG: access_secret_version: Secret 'projects/dev-pool-prj3/secrets/hpccluster-slurm-secret-cloudsql/versions/latest' was found.
DEBUG: compute_service: Using version=v1 of Google Compute Engine API
INFO: JWT key already exists. Skipping key generation.
INFO: Munge key already exists. Skipping key generation.
INFO: Set up network storage
INFO: Setting up mount (nfs) 10.0.0.2:/exports/data to /data
INFO: Waiting for '/data' to be mounted...
INFO: Mount point '/data' was mounted.
DEBUG: run_custom_scripts: custom scripts to run: /slurm/custom_scripts/(controller.d/ghpc_startup.sh)
INFO: running script ghpc_startup.sh with timeout=300
INFO: ghpc_startup.sh returncode=0
stdout=stderr=
INFO: Check status of cluster services
INFO: Done setting up controller
                                                                               
*** Slurm controller setup complete ***
```

We can also see that it is connected to the private IP rather than localhost.
```
StorageType=accounting_storage/mysql
StorageHost=10.216.0.3
StoragePort=3306
StorageUser=slurm
StoragePass=aNHwVUE4F96u=
```
