### PR TITLE
Merge 5.10.1 release into GCP fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## \[5.10.1\]
+
+- Add maintenance_interval
+
 ## \[5.10.0\]
 
 - Upgrade slurm to 23.02.7

--- a/terraform/slurm_cluster/examples/slurm_cluster/cloud/basic/example.tfvars
+++ b/terraform/slurm_cluster/examples/slurm_cluster/cloud/basic/example.tfvars
@@ -339,10 +339,11 @@ partitions = [
           #   network_tier = null
           # },
         ]
-        additional_networks = []
-        bandwidth_tier      = "platform_default"
-        enable_spot_vm      = false
-        reservation_name    = null
+        additional_networks  = []
+        bandwidth_tier       = "platform_default"
+        enable_spot_vm       = false
+        reservation_name     = null
+        maintenance_interval = null
         spot_instance_config = {
           termination_action = "STOP"
         }
@@ -413,11 +414,12 @@ partitions = [
         instance_template = null
 
         # Instance Definition
-        access_config       = []
-        additional_networks = []
-        bandwidth_tier      = "platform_default"
-        enable_spot_vm      = false
-        reservation_name    = null
+        access_config        = []
+        additional_networks  = []
+        bandwidth_tier       = "platform_default"
+        enable_spot_vm       = false
+        reservation_name     = null
+        maintenance_interval = null
         spot_instance_config = {
           termination_action = "STOP"
         }

--- a/terraform/slurm_cluster/examples/slurm_cluster/cloud/full/example.tfvars
+++ b/terraform/slurm_cluster/examples/slurm_cluster/cloud/full/example.tfvars
@@ -330,10 +330,11 @@ partitions = [
           #   network_tier = null
           # },
         ]
-        additional_networks = []
-        bandwidth_tier      = "platform_default"
-        enable_spot_vm      = false
-        reservation_name    = null
+        additional_networks  = []
+        bandwidth_tier       = "platform_default"
+        enable_spot_vm       = false
+        reservation_name     = null
+        maintenance_interval = null
         spot_instance_config = {
           termination_action = "STOP"
         }
@@ -396,11 +397,12 @@ partitions = [
         instance_template = null
 
         # Instance Definition
-        access_config       = []
-        additional_networks = []
-        bandwidth_tier      = "platform_default"
-        enable_spot_vm      = false
-        reservation_name    = null
+        access_config        = []
+        additional_networks  = []
+        bandwidth_tier       = "platform_default"
+        enable_spot_vm       = false
+        reservation_name     = null
+        maintenance_interval = null
         spot_instance_config = {
           termination_action = "STOP"
         }

--- a/terraform/slurm_cluster/examples/slurm_cluster/hybrid/basic/example.tfvars
+++ b/terraform/slurm_cluster/examples/slurm_cluster/hybrid/basic/example.tfvars
@@ -188,10 +188,11 @@ partitions = [
           #   network_tier = null
           # },
         ]
-        additional_networks = []
-        bandwidth_tier      = "platform_default"
-        enable_spot_vm      = false
-        reservation_name    = null
+        additional_networks  = []
+        bandwidth_tier       = "platform_default"
+        enable_spot_vm       = false
+        reservation_name     = null
+        maintenance_interval = null
         spot_instance_config = {
           termination_action = "STOP"
         }
@@ -262,10 +263,11 @@ partitions = [
         instance_template = null
 
         # Instance Definition
-        access_config    = []
-        bandwidth_tier   = "platform_default"
-        enable_spot_vm   = false
-        reservation_name = null
+        access_config        = []
+        bandwidth_tier       = "platform_default"
+        enable_spot_vm       = false
+        reservation_name     = null
+        maintenance_interval = null
         spot_instance_config = {
           termination_action = "STOP"
         }

--- a/terraform/slurm_cluster/examples/slurm_cluster/hybrid/full/example.tfvars
+++ b/terraform/slurm_cluster/examples/slurm_cluster/hybrid/full/example.tfvars
@@ -190,10 +190,11 @@ partitions = [
           #   network_tier = null
           # },
         ]
-        additional_networks = []
-        bandwidth_tier      = "platform_default"
-        enable_spot_vm      = false
-        reservation_name    = null
+        additional_networks  = []
+        bandwidth_tier       = "platform_default"
+        enable_spot_vm       = false
+        reservation_name     = null
+        maintenance_interval = null
         spot_instance_config = {
           termination_action = "STOP"
         }
@@ -256,11 +257,12 @@ partitions = [
         instance_template = null
 
         # Instance Definition
-        access_config       = []
-        additional_networks = []
-        bandwidth_tier      = "platform_default"
-        enable_spot_vm      = false
-        reservation_name    = null
+        access_config        = []
+        additional_networks  = []
+        bandwidth_tier       = "platform_default"
+        enable_spot_vm       = false
+        reservation_name     = null
+        maintenance_interval = null
         spot_instance_config = {
           termination_action = "STOP"
         }

--- a/terraform/slurm_cluster/modules/slurm_controller_instance/main.tf
+++ b/terraform/slurm_cluster/modules/slurm_controller_instance/main.tf
@@ -20,8 +20,8 @@
 
 locals {
   region = (
-    length(regexall("/regions/([^/]*)", var.subnetwork)) > 0
-    ? flatten(regexall("/regions/([^/]*)", var.subnetwork))[0]
+    length(regexall("/regions/([^/]*)", var.subnetwork != null ? var.subnetwork : "")) > 0
+    ? flatten(regexall("/regions/([^/]*)", var.subnetwork != null ? var.subnetwork : ""))[0]
     : var.region
   )
 

--- a/test/arm64-basic.tfvars.tpl
+++ b/test/arm64-basic.tfvars.tpl
@@ -172,6 +172,7 @@ partitions = [
         bandwidth_tier = "platform_default"
         enable_spot_vm = false
         reservation_name = null
+        maintenance_interval = null
         spot_instance_config = {
           termination_action = "STOP"
         }
@@ -262,6 +263,7 @@ partitions = [
         bandwidth_tier = "platform_default"
         enable_spot_vm = true
         reservation_name = null
+        maintenance_interval = null
         spot_instance_config = {
           termination_action = "STOP"
         }
@@ -338,6 +340,7 @@ partitions = [
         bandwidth_tier = "platform_default"
         enable_spot_vm = false
         reservation_name = null
+        maintenance_interval = null
         spot_instance_config = {
           termination_action = "STOP"
         }

--- a/test/x86_64-basic.tfvars.tpl
+++ b/test/x86_64-basic.tfvars.tpl
@@ -172,6 +172,7 @@ partitions = [
         bandwidth_tier = "platform_default"
         enable_spot_vm = false
         reservation_name = null
+        maintenance_interval = null
         spot_instance_config = {
           termination_action = "STOP"
         }
@@ -247,6 +248,7 @@ partitions = [
         bandwidth_tier = "platform_default"
         enable_spot_vm = false
         reservation_name = null
+        maintenance_interval = null
         spot_instance_config = {
           termination_action = "STOP"
         }
@@ -336,6 +338,7 @@ partitions = [
         bandwidth_tier = "platform_default"
         enable_spot_vm = false
         reservation_name = null
+        maintenance_interval = null
         spot_instance_config = {
           termination_action = "STOP"
         }
@@ -425,6 +428,7 @@ partitions = [
         bandwidth_tier = "platform_default"
         enable_spot_vm = true
         reservation_name = null
+        maintenance_interval = null
         spot_instance_config = {
           termination_action = "STOP"
         }
@@ -504,6 +508,7 @@ partitions = [
         bandwidth_tier = "platform_default"
         enable_spot_vm = false
         reservation_name = null
+        maintenance_interval = null
         spot_instance_config = {
           termination_action = "STOP"
         }
@@ -580,6 +585,7 @@ partitions = [
         bandwidth_tier = "platform_default"
         enable_spot_vm = false
         reservation_name = null
+        maintenance_interval = null
         spot_instance_config = {
           termination_action = "STOP"
         }


### PR DESCRIPTION
This PR will merge the 5.10.1 release from SchedMD into the GoogleCloudPlatform fork of slurm-gcp. This branch was produced by rebasing the tip of SchedMD/slurm-gcp:v5 onto GoogleCloudPlatform/slurm-gcp:v5.