### PR TITLE
Configure slurmd to restart upon-failure

### DIFF
--- a/ansible/roles/slurm/defaults/main.yml
+++ b/ansible/roles/slurm/defaults/main.yml
@@ -38,3 +38,5 @@ slurmrestd_user:
   uid: 982
   group: slurmrestd
   gid: 982
+
+slurmd_override_path: /etc/systemd/system/slurmd.service.d/slurmd_restart.conf

--- a/ansible/roles/slurm/handlers/main.yml
+++ b/ansible/roles/slurm/handlers/main.yml
@@ -48,3 +48,7 @@
     name: slurm_load_bq.timer
     enabled: no
     state: stopped
+
+- name: Reload SystemD configuration
+  systemd:
+    daemon_reload: true

--- a/ansible/roles/slurm/tasks/service.yml
+++ b/ansible/roles/slurm/tasks/service.yml
@@ -33,3 +33,15 @@
     dest: /usr/lib/systemd/system/slurm_load_bq.timer
     mode: 0o644
   notify: Handle slurm_load_bigquery Timer
+
+- name: Create slurmd override directory
+  file:
+    path: "{{ slurmd_override_path | dirname }}"
+    state: directory
+
+- name: Slurmd should restart upon failure
+  template:
+    src: systemd/slurmd_restart_override.j2
+    dest: "{{ slurmd_override_path }}"
+    mode: 0o644
+  notify: Reload SystemD configuration

--- a/ansible/roles/slurm/templates/systemd/slurmd_restart_override.j2
+++ b/ansible/roles/slurm/templates/systemd/slurmd_restart_override.j2
@@ -1,0 +1,3 @@
+[Service]
+RestartSec=15s
+Restart=on-failure


### PR DESCRIPTION
In "config-less" mode for login and compute nodes, slurmd will contact the controller upon boot and request its configuration. It does not retry if the controller happens to be down, even momentarily. This configures SystemD to restart slurmd continually. This is an extremely simple configuration that is CentOS 7 compatible; more sophisticated backoff and rate limiting can be applied in later releases of SystemD.