### PR TITLE
Merge from SchedMD/slurm-gcp v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## \[5.10.2\]
+
+- Fix slurmsync error on removing powered up nodes.
+
 ## \[5.10.1\]
 
 - Add maintenance_interval

--- a/scripts/slurmsync.py
+++ b/scripts/slurmsync.py
@@ -112,9 +112,9 @@ def find_node_status(nodename):
         find_node_status.static_nodeset = set(util.to_hostnames(lkp.static_nodelist()))
     state = lkp.slurm_node(nodename)
     inst = lkp.instance(nodename)
-    power_flags = state.flags & frozenset(
+    power_flags = frozenset(
         ("POWER_DOWN", "POWERING_UP", "POWERING_DOWN", "POWERED_DOWN")
-    )
+    ) & (state.flags if state is not None else set())
     if inst is None:
         if "POWERING_UP" in state.flags:
             return NodeStatus.unchanged


### PR DESCRIPTION
There is a lot going on here, most of which is due to the number of Slurm releases in December with no v5 releases. We also decided mid-release to put Slurm 23.02 on v5.

Do you want to clean up the CHANGELOG at all? Are you still using it going forward?