### PR TITLE
Change man2html to man2html-base dependency

### DIFF
--- a/ansible/roles/slurm/tasks/service.yml
+++ b/ansible/roles/slurm/tasks/service.yml
@@ -36,12 +36,12 @@
 
 - name: Create slurmd override directory
   file:
-    path: "{{ slurmd_override_path | dirname }}"
+    path: '{{ slurmd_override_path | dirname }}'
     state: directory
 
 - name: Slurmd should restart upon failure
   template:
     src: systemd/slurmd_restart_override.j2
-    dest: "{{ slurmd_override_path }}"
+    dest: '{{ slurmd_override_path }}'
     mode: 0o644
   notify: Reload SystemD configuration

--- a/ansible/roles/slurm/vars/debian-10.yml
+++ b/ansible/roles/slurm/vars/debian-10.yml
@@ -38,6 +38,6 @@ slurm_packages:
 - libssl-dev
 - libyaml-dev
 - lua5.3
-- man2html
+- man2html-base
 - numactl
 - rrdtool

--- a/ansible/roles/slurm/vars/debian-11.yml
+++ b/ansible/roles/slurm/vars/debian-11.yml
@@ -38,6 +38,6 @@ slurm_packages:
 - libssl-dev
 - libyaml-dev
 - lua5.3
-- man2html
+- man2html-base
 - numactl
 - rrdtool

--- a/ansible/roles/slurm/vars/redhat-7.yml
+++ b/ansible/roles/slurm/vars/redhat-7.yml
@@ -30,7 +30,7 @@ slurm_packages:
 - lua
 - lua-devel
 - lz4-devel
-- man2html
+- man2html-core
 - ncurses-devel
 - numactl
 - numactl-devel

--- a/ansible/roles/slurm/vars/rocky-8.yml
+++ b/ansible/roles/slurm/vars/rocky-8.yml
@@ -30,7 +30,7 @@ slurm_packages:
 - lua
 - lua-devel
 - lz4-devel
-- man2html
+- man2html-core
 - ncurses-devel
 - numactl
 - numactl-devel

--- a/ansible/roles/slurm/vars/ubuntu-20.04.yml
+++ b/ansible/roles/slurm/vars/ubuntu-20.04.yml
@@ -38,6 +38,6 @@ slurm_packages:
 - libssl-dev
 - libyaml-dev
 - lua5.3
-- man2html
+- man2html-base
 - numactl
 - rrdtool

--- a/ansible/roles/slurm/vars/ubuntu-22.04.yml
+++ b/ansible/roles/slurm/vars/ubuntu-22.04.yml
@@ -38,6 +38,6 @@ slurm_packages:
 - libssl-dev
 - libyaml-dev
 - lua5.3
-- man2html
+- man2html-base
 - numactl
 - rrdtool

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -620,8 +620,9 @@ def run_custom_scripts():
                 timeout = lkp.cfg.get("controller_startup_scripts_timeout", 300)
             elif "/compute.d/" in str(script):
                 timeout = lkp.cfg.get("compute_startup_scripts_timeout", 300)
-            elif "/login.d/" in str(script) or \
-                 (suffix is not None and f"/login_{suffix}.d/" in str(script)):
+            elif "/login.d/" in str(script) or (
+                suffix is not None and f"/login_{suffix}.d/" in str(script)
+            ):
                 timeout = lkp.cfg.get("login_startup_scripts_timeout", 300)
             elif "/partition.d/" in str(script):
                 partition_name = lkp.node_partition_name()

--- a/test/cloud-build/pr-validation.yaml
+++ b/test/cloud-build/pr-validation.yaml
@@ -1,0 +1,13 @@
+---
+
+steps:
+- id: pre-commit
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    git init --quiet .
+    git add .
+    pre-commit run --all-files


### PR DESCRIPTION
Changing this dependency to only the base or core one, we make that apache does not get installed as a dependency, making the image lighter. On Debian and Ubuntu platforms this has the additional impact that the apache2.service does not start.

(cherry picked from commit cf8ee0074c7e57fd5974696e1c332315fef8769b)