### PR TITLE
slurmsync.py: fix concurrent invocation protection on v5 branch

### DIFF
--- a/scripts/slurmsync.py
+++ b/scripts/slurmsync.py
@@ -388,7 +388,6 @@ if __name__ == "__main__":
     with pid_file.open("w") as fp:
         try:
             fcntl.lockf(fp, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except IOError:
+            main()
+        except BlockingIOError:
             sys.exit(0)
-
-    main()


### PR DESCRIPTION
Backport #14 to v5 release branch to ensure that slurmsync cannot be invoked multiple times simultaneously - whether by the user or cron.