### PR TITLE
Document 6.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## \[6.4.0\]
+
+- enable explicit setting of maintenance_interval to nodesets
+- Fix solution for installing Lustre drivers in Rocky Linux 8
+
 ## \[6.3.5\]
 
 - Change slurm version to 23.11.3

--- a/ansible/roles/kernel/tasks/os/redhat-8.yml
+++ b/ansible/roles/kernel/tasks/os/redhat-8.yml
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 - name: Install {{ansible_os_family}} Family Kernel Packages
   dnf:
     name:
@@ -23,14 +22,12 @@
     - kernel-tools
     - kernel-tools-libs
     #- kernel-tools-libs-devel
+    - '{{ ansible_distribution | lower }}-release'
     state: latest
     update_cache: yes
-
 - block:
   - name: Reboot
     reboot:
-
   - name: Gather facts after reboot
     setup:
-
   when: reboot

--- a/ansible/roles/lustre/vars/redhat-8.yml
+++ b/ansible/roles/lustre/vars/redhat-8.yml
@@ -12,9 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-lustre_repo_url: https://downloads.whamcloud.com/public/lustre/latest-release/el8.9/client
-
+lustre_repo_url: https://downloads.whamcloud.com/public/lustre/latest-release/el{{ansible_distribution_version}}/client
 lustre_packages:
 - lustre-client
 - lustre-client-dkms


### PR DESCRIPTION
- enable explicit setting of maintenance_interval to nodesets
- Fix solution for installing lustre in Rocky Linux 8