### PR TITLE
Changes to Lustre installation (v5)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,15 +26,6 @@ repos:
     additional_dependencies:
     - mdformat-toc
     - mdformat-tables
-- repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
-  rev: 0.2.3
-  hooks:
-  - id: yamlfmt
-    args:
-    - --mapping=2
-    - --sequence=2
-    - --offset=0
-    - --width=80
 - repo: local
   hooks:
   - id: packer_fmt

--- a/ansible/roles/kernel/tasks/os/redhat-8.yml
+++ b/ansible/roles/kernel/tasks/os/redhat-8.yml
@@ -23,6 +23,7 @@
     - kernel-tools
     - kernel-tools-libs
     #- kernel-tools-libs-devel
+    - '{{ ansible_distribution | lower }}-release'
     state: latest
     update_cache: yes
 

--- a/ansible/roles/lustre/tasks/os/redhat.yml
+++ b/ansible/roles/lustre/tasks/os/redhat.yml
@@ -17,6 +17,6 @@
   ansible.builtin.yum_repository:
     name: lustre-client
     description: Lustre Client
-    baseurl: '{{ lustre_repo_url }} {{ lustre_repo_url_fallback or "" }}'
+    baseurl: '{{ lustre_repo_url }}'
     enabled: true
     gpgcheck: false

--- a/ansible/roles/lustre/vars/redhat-7.yml
+++ b/ansible/roles/lustre/vars/redhat-7.yml
@@ -15,8 +15,6 @@
 
 lustre_repo_url: https://downloads.whamcloud.com/public/lustre/latest-2.12-release/el7/client
 
-lustre_repo_url_fallback: https://downloads.whamcloud.com/public/lustre/lustre-2.12.9/el7/client
-
 lustre_packages:
 - lustre-client
 - lustre-client-dkms

--- a/ansible/roles/lustre/vars/redhat-8.yml
+++ b/ansible/roles/lustre/vars/redhat-8.yml
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-lustre_repo_url: https://downloads.whamcloud.com/public/lustre/latest-release/el8.8/client
-
-lustre_repo_url_fallback: https://downloads.whamcloud.com/public/lustre/lustre-2.15.3/el8.8/client
+lustre_repo_url: https://downloads.whamcloud.com/public/lustre/latest-release/el{{ ansible_distribution_version }}/client
 
 lustre_packages:
 - lustre-client


### PR DESCRIPTION
The existing solution for installing lustre breaks whenever new point releases of Rocky linux are made because it upgrades the kernel packages without also upgrading rocky-release (which is what tells the OS whether it is 8.8 or 8.9 via the /etc/os-release file).

The new solution makes the assumption that, after upgrading the kernel and rocky-release packages that:

- we are running the latest version of Rocky Linux (safe assumption)
- that the latest-release of DDN's packaged lustre supports the latest version of Rocky linux (probably unsafe immediately after release)

This solution is "less unsafe" because, if DDN has not yet packaged a version of lustre for the latest Rocky, then Ansible will fail. The current solution will successfully install lustre, but for the older kernel it is no longer booting. So the failure mode will not be detected during image build.