### PR TITLE
Release 6.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## \[6.4.0\]
+
+- enable explicit setting of maintenance_interval to nodesets
+- Fix solution for installing Lustre drivers in Rocky Linux 8
+
 ## \[6.3.5\]
 
 - Change slurm version to 23.11.3

--- a/ansible/roles/kernel/tasks/os/redhat-8.yml
+++ b/ansible/roles/kernel/tasks/os/redhat-8.yml
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 - name: Install {{ansible_os_family}} Family Kernel Packages
   dnf:
     name:
@@ -23,14 +22,12 @@
     - kernel-tools
     - kernel-tools-libs
     #- kernel-tools-libs-devel
+    - '{{ ansible_distribution | lower }}-release'
     state: latest
     update_cache: yes
-
 - block:
   - name: Reboot
     reboot:
-
   - name: Gather facts after reboot
     setup:
-
   when: reboot

--- a/ansible/roles/lustre/vars/redhat-8.yml
+++ b/ansible/roles/lustre/vars/redhat-8.yml
@@ -12,9 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-lustre_repo_url: https://downloads.whamcloud.com/public/lustre/latest-release/el8.9/client
-
+lustre_repo_url: https://downloads.whamcloud.com/public/lustre/latest-release/el{{ansible_distribution_version}}/client
 lustre_packages:
 - lustre-client
 - lustre-client-dkms

--- a/ansible/roles/slurm/defaults/main.yml
+++ b/ansible/roles/slurm/defaults/main.yml
@@ -15,7 +15,7 @@
 
 slurm_git_url: https://github.com/SchedMD/slurm.git
 slurm_tar_baseurl: https://download.schedmd.com/slurm
-slurm_version: 23.02.6
+slurm_version: 23.11.3
 
 slurm_paths:
   install: '{{paths.install}}'

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -227,7 +227,7 @@ across all instances and allows easy user control with
 
 By default, the [slurm_cluster](../terraform/slurm_cluster/README.md) terraform
 module uses the latest Slurm image family (e.g.
-`slurm-gcp-6-3-hpc-rocky-linux-8`). As new Slurm image families are released,
+`slurm-gcp-6-4-hpc-rocky-linux-8`). As new Slurm image families are released,
 coenciding with periodic Slurm releases, the terraform module will be updated to
 track the newest image family by setting it as the new default. This update can
 be considered a breaking change.

--- a/docs/images.md
+++ b/docs/images.md
@@ -74,12 +74,12 @@ For the [TPU](./glossary.md#tpu) nodes docker images are also released.
 
 |       Project        | Image Family                        | Arch   | Status         |
 | :------------------: | :---------------------------------- | :----- | :------------- |
-| schedmd-slurm-public | slurm-gcp-6-3-debian-11             | x86_64 | Supported      |
-| schedmd-slurm-public | slurm-gcp-6-3-hpc-rocky-linux-8     | x86_64 | Supported      |
-| schedmd-slurm-public | slurm-gcp-6-3-ubuntu-2004-lts       | x86_64 | Supported      |
-| schedmd-slurm-public | slurm-gcp-6-3-ubuntu-2204-lts-arm64 | ARM64  | Supported      |
-| schedmd-slurm-public | slurm-gcp-6-3-hpc-centos-7-k80      | x86_64 | EOL 2024-05-01 |
-| schedmd-slurm-public | slurm-gcp-6-3-hpc-centos-7          | x86_64 | EOL 2024-01-01 |
+| schedmd-slurm-public | slurm-gcp-6-4-debian-11             | x86_64 | Supported      |
+| schedmd-slurm-public | slurm-gcp-6-4-hpc-rocky-linux-8     | x86_64 | Supported      |
+| schedmd-slurm-public | slurm-gcp-6-4-ubuntu-2004-lts       | x86_64 | Supported      |
+| schedmd-slurm-public | slurm-gcp-6-4-ubuntu-2204-lts-arm64 | ARM64  | Supported      |
+| schedmd-slurm-public | slurm-gcp-6-4-hpc-centos-7-k80      | x86_64 | EOL 2024-05-01 |
+| schedmd-slurm-public | slurm-gcp-6-4-hpc-centos-7          | x86_64 | EOL 2024-01-01 |
 
 ### Published Docker Image Family
 

--- a/docs/images.md
+++ b/docs/images.md
@@ -85,17 +85,17 @@ For the [TPU](./glossary.md#tpu) nodes docker images are also released.
 
 |       Project        | Image Family                | Status    |
 | :------------------: | :-------------------------- | :-------- |
-| schedmd-slurm-public | tpu:slurm-gcp-6-2-tf-2.8.0  | Supported |
-| schedmd-slurm-public | tpu:slurm-gcp-6-2-tf-2.8.3  | Supported |
-| schedmd-slurm-public | tpu:slurm-gcp-6-2-tf-2.9.1  | Supported |
-| schedmd-slurm-public | tpu:slurm-gcp-6-2-tf-2.9.3  | Supported |
-| schedmd-slurm-public | tpu:slurm-gcp-6-2-tf-2.10.0 | Supported |
-| schedmd-slurm-public | tpu:slurm-gcp-6-2-tf-2.10.1 | Supported |
-| schedmd-slurm-public | tpu:slurm-gcp-6-2-tf-2.11.0 | Supported |
-| schedmd-slurm-public | tpu:slurm-gcp-6-2-tf-2.11.1 | Supported |
-| schedmd-slurm-public | tpu:slurm-gcp-6-2-tf-2.12.0 | Supported |
-| schedmd-slurm-public | tpu:slurm-gcp-6-2-tf-2.12.1 | Supported |
-| schedmd-slurm-public | tpu:slurm-gcp-6-2-tf-2.13.0 | Supported |
+| schedmd-slurm-public | tpu:slurm-gcp-6-4-tf-2.8.0  | Supported |
+| schedmd-slurm-public | tpu:slurm-gcp-6-4-tf-2.8.3  | Supported |
+| schedmd-slurm-public | tpu:slurm-gcp-6-4-tf-2.9.1  | Supported |
+| schedmd-slurm-public | tpu:slurm-gcp-6-4-tf-2.9.3  | Supported |
+| schedmd-slurm-public | tpu:slurm-gcp-6-4-tf-2.10.0 | Supported |
+| schedmd-slurm-public | tpu:slurm-gcp-6-4-tf-2.10.1 | Supported |
+| schedmd-slurm-public | tpu:slurm-gcp-6-4-tf-2.11.0 | Supported |
+| schedmd-slurm-public | tpu:slurm-gcp-6-4-tf-2.11.1 | Supported |
+| schedmd-slurm-public | tpu:slurm-gcp-6-4-tf-2.12.0 | Supported |
+| schedmd-slurm-public | tpu:slurm-gcp-6-4-tf-2.12.1 | Supported |
+| schedmd-slurm-public | tpu:slurm-gcp-6-4-tf-2.13.0 | Supported |
 
 ## Custom Image
 

--- a/docs/tpu.md
+++ b/docs/tpu.md
@@ -72,12 +72,12 @@ state we will also include if it is tested or not.
 
 |       Project        | Image Family                        | Arch   | TPU Status  |
 | :------------------: | :---------------------------------- | :----- | :---------- |
-| schedmd-slurm-public | slurm-gcp-6-3-debian-11             | x86_64 | Untested    |
-| schedmd-slurm-public | slurm-gcp-6-3-hpc-rocky-linux-8     | x86_64 | Tested      |
-| schedmd-slurm-public | slurm-gcp-6-3-ubuntu-2004-lts       | x86_64 | Untested    |
-| schedmd-slurm-public | slurm-gcp-6-3-ubuntu-2204-lts-arm64 | ARM64  | Untested    |
-| schedmd-slurm-public | slurm-gcp-6-3-hpc-centos-7-k80      | x86_64 | Unsupported |
-| schedmd-slurm-public | slurm-gcp-6-3-hpc-centos-7          | x86_64 | Unsupported |
+| schedmd-slurm-public | slurm-gcp-6-4-debian-11             | x86_64 | Untested    |
+| schedmd-slurm-public | slurm-gcp-6-4-hpc-rocky-linux-8     | x86_64 | Tested      |
+| schedmd-slurm-public | slurm-gcp-6-4-ubuntu-2004-lts       | x86_64 | Untested    |
+| schedmd-slurm-public | slurm-gcp-6-4-ubuntu-2204-lts-arm64 | ARM64  | Untested    |
+| schedmd-slurm-public | slurm-gcp-6-4-hpc-centos-7-k80      | x86_64 | Unsupported |
+| schedmd-slurm-public | slurm-gcp-6-4-hpc-centos-7          | x86_64 | Unsupported |
 
 ## Terraform
 

--- a/terraform/slurm_cluster/modules/slurm_instance_template/main.tf
+++ b/terraform/slurm_cluster/modules/slurm_instance_template/main.tf
@@ -47,7 +47,7 @@ locals {
   source_image_family = (
     var.source_image_family != "" && var.source_image_family != null
     ? var.source_image_family
-    : "slurm-gcp-6-3-hpc-rocky-linux-8"
+    : "slurm-gcp-6-4-hpc-rocky-linux-8"
   )
   source_image_project = (
     var.source_image_project != "" && var.source_image_project != null

--- a/terraform/slurm_cluster/modules/slurm_nodeset_tpu/README_TF.md
+++ b/terraform/slurm_cluster/modules/slurm_nodeset_tpu/README_TF.md
@@ -49,7 +49,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_accelerator_config"></a> [accelerator\_config](#input\_accelerator\_config) | Nodeset accelerator config, see https://cloud.google.com/tpu/docs/supported-tpu-configurations for details. | <pre>object({<br>    topology = string<br>    version  = string<br>  })</pre> | <pre>{<br>  "topology": "",<br>  "version": ""<br>}</pre> | no |
 | <a name="input_data_disks"></a> [data\_disks](#input\_data\_disks) | The data disks to include in the TPU node | `list(string)` | `[]` | no |
-| <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | The gcp container registry id docker image to use in the TPU vms, it defaults to gcr.io/schedmd-slurm-public/tpu:slurm-gcp-6-3-tf-<var.tf\_version> | `string` | `""` | no |
+| <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | The gcp container registry id docker image to use in the TPU vms, it defaults to gcr.io/schedmd-slurm-public/tpu:slurm-gcp-6-4-tf-<var.tf\_version> | `string` | `""` | no |
 | <a name="input_enable_public_ip"></a> [enable\_public\_ip](#input\_enable\_public\_ip) | Enables IP address to access the Internet. | `bool` | `false` | no |
 | <a name="input_node_count_dynamic_max"></a> [node\_count\_dynamic\_max](#input\_node\_count\_dynamic\_max) | Maximum number of nodes allowed in this partition to be created dynamically. | `number` | `0` | no |
 | <a name="input_node_count_static"></a> [node\_count\_static](#input\_node\_count\_static) | Number of nodes to be statically created. | `number` | `0` | no |

--- a/terraform/slurm_cluster/modules/slurm_nodeset_tpu/main.tf
+++ b/terraform/slurm_cluster/modules/slurm_nodeset_tpu/main.tf
@@ -68,7 +68,7 @@ locals {
     service_account        = var.service_account != null ? var.service_account : local.service_account
     preserve_tpu           = local.can_preempt ? var.preserve_tpu : false
     data_disks             = var.data_disks
-    docker_image           = var.docker_image != "" ? var.docker_image : "gcr.io/schedmd-slurm-public/tpu:slurm-gcp-6-3-tf-${var.tf_version}"
+    docker_image           = var.docker_image != "" ? var.docker_image : "gcr.io/schedmd-slurm-public/tpu:slurm-gcp-6-4-tf-${var.tf_version}"
     subnetwork             = local.snetwork
   }
 

--- a/terraform/slurm_cluster/modules/slurm_nodeset_tpu/variables.tf
+++ b/terraform/slurm_cluster/modules/slurm_nodeset_tpu/variables.tf
@@ -51,7 +51,7 @@ variable "accelerator_config" {
 }
 
 variable "docker_image" {
-  description = "The gcp container registry id docker image to use in the TPU vms, it defaults to gcr.io/schedmd-slurm-public/tpu:slurm-gcp-6-3-tf-<var.tf_version>"
+  description = "The gcp container registry id docker image to use in the TPU vms, it defaults to gcr.io/schedmd-slurm-public/tpu:slurm-gcp-6-4-tf-<var.tf_version>"
   type        = string
   default     = ""
 }


### PR DESCRIPTION
Full set of changes from 6.3.5 to 6.4.0:

- enable explicit setting of maintenance_interval to nodesets (https://github.com/GoogleCloudPlatform/slurm-gcp/pull/39) 
- Fix solution for installing Lustre drivers in Rocky Linux 8 (included in this PR)
- Update default VM image families and docker images