### PR TITLE
Release 6.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## \[6.4.1\]
+
+- Fix regression in slurmsync that would cause inadvertent deletion of compact
+  placement policies right before they are used
+- Remove configuration settings that are no longer valid in Slurm 23.11
+  - CommunicationParameters: NoAddrCache
+  - CgroupAutomount
+- Use beta API for Google Compute Engine due to usage of maintenanceInterval
+  setting on VMs
+
 ## \[6.4.0\]
 
 - enable explicit setting of maintenance_interval to nodesets

--- a/etc/cgroup.conf.tpl
+++ b/etc/cgroup.conf.tpl
@@ -1,8 +1,6 @@
 # cgroup.conf
 # https://slurm.schedmd.com/cgroup.conf.html
 
-CgroupAutomount=no
-#CgroupMountpoint=/sys/fs/cgroup
 ConstrainCores=yes
 ConstrainRamSpace=yes
 ConstrainSwapSpace=no

--- a/scripts/conf.py
+++ b/scripts/conf.py
@@ -91,9 +91,6 @@ def conflines(cloud_parameters, lkp=lkp):
             "salloc_wait_nodes",
             "ignore_prefer_validation",
         ],
-        "CommunicationParameters": [
-            "NoAddrCache",
-        ],
         "GresTypes": [
             "gpu" if any_gpus else None,
         ],

--- a/scripts/slurmsync.py
+++ b/scripts/slurmsync.py
@@ -334,7 +334,7 @@ def sync_placement_groups():
     keep_jobs = {
         str(job["job_id"])
         for job in json.loads(run(f"{lkp.scontrol} show jobs --json").stdout)["jobs"]
-        if (len(job["job_state"]) == 1) and (job["job_state"][0] in keep_states)
+        if "job_state" in job and set(job["job_state"]) & keep_states
     }
 
     fields = "items.regions.resourcePolicies,nextPageToken"

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -318,7 +318,7 @@ def reservation_resource_policies(reservation):
     return [u.split("/")[-1] for u in reservation.get("resourcePolicies", {}).values()]
 
 
-def compute_service(credentials=None, user_agent=USER_AGENT, version="v1"):
+def compute_service(credentials=None, user_agent=USER_AGENT, version="beta"):
     """Make thread-safe compute service handle
     creates a new Http for each request
     """


### PR DESCRIPTION
This PR contains the changes for patchfix release 6.4.1. Integration tests are being run against it at:

https://github.com/GoogleCloudPlatform/hpc-toolkit/pull/2230/checks

## Changes

- Fix regression in slurmsync that would cause inadvertent deletion of compact placement policies right before they are used
- Remove configuration settings that are no longer valid in Slurm 23.11
  - CommunicationParameters: NoAddrCache
  - CgroupAutomount
- Use beta API for Google Compute Engine due to usage of maintenanceInterval setting on VMs