### PR TITLE
Fix: sync would try to delete static placement policy as it is not associated with a job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## \[6.4.2\]
+
+- Fix slurmsync.py would try to delete static placement policy as it is not
+  associated with a job. This delete would fail as nodes were using the
+  placement policy, but it would cause spurious failure error messages in logs.
+
 ## \[6.4.1\]
 
 - Fix regression in slurmsync that would cause inadvertent deletion of compact

--- a/scripts/slurmsync.py
+++ b/scripts/slurmsync.py
@@ -336,6 +336,7 @@ def sync_placement_groups():
         for job in json.loads(run(f"{lkp.scontrol} show jobs --json").stdout)["jobs"]
         if "job_state" in job and set(job["job_state"]) & keep_states
     }
+    keep_jobs.add("0")  # Job 0 is a placeholder for static node placement
 
     fields = "items.regions.resourcePolicies,nextPageToken"
     flt = f"name={lkp.cfg.slurm_cluster_name}-*"


### PR DESCRIPTION
Fix slurmsync.py would try to delete static placement policy as it is not associated with a job. This delete would fail as nodes were using the placement policy, but it would cause spurious failure error messages in logs.