### PR TITLE
Fix readme

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,16 +16,23 @@ repos:
   - id: end-of-file-fixer
   - id: trailing-whitespace
   - id: detect-private-key
-- repo: https://github.com/executablebooks/mdformat
-  rev: 0.7.17
+- repo: https://github.com/jackdewinter/pymarkdown
+  rev: v0.9.17
   hooks:
-  - id: mdformat
-    args:
-    - --wrap=80
-    exclude: README_TF\.md
-    additional_dependencies:
-    - mdformat-toc
-    - mdformat-tables
+  - id: pymarkdown
+    # Rules at https://github.com/jackdewinter/pymarkdown/tree/main/docs/rules
+    # MD013 - Line length
+    # MD022 - Headers should be surrounded by blank lines
+    # MD033 - Inline HTML
+    # MD034 - Bare URL used
+    # MD041 - First line in file should be a top level header
+    # MD046 - Code block style
+    # MD024 - Multiple headings cannot contain the same content.
+    args: [--disable-rules, 'MD013,MD022,MD033,MD034,MD041,MD046,MD024', scan]
+    # this is a temporary hack to disable pymarkdown until all files are brought
+    # in line with its expectations
+    exclude_types:
+    - markdown
 - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
   rev: 0.2.3
   hooks:

--- a/README.md
+++ b/README.md
@@ -1,24 +1,20 @@
 # Slurm on Google Cloud Platform
 
-______________________________________________________________________
+## Guidance on usage
 
-> \[!CAUTION\] Terraform modules in this repo are not meant to be used directly.
->
-> Instead,
-> [Google HPC-Toolkit](https://github.com/GoogleCloudPlatform/hpc-toolkit) is
-> the recommended way to use Slurm in GCP.
+> [!CAUTION]
+> Terraform modules in this repo are not meant to be used directly. Instead,
+> [Cloud HPC Toolkit](https://github.com/GoogleCloudPlatform/hpc-toolkit) is the
+> recommended way to use Slurm in GCP.
 
-______________________________________________________________________
+## Notices
 
-#### NOTICE
-
-##### 5.7.3
-
-The naming scheme for SchedMD published images has changed with release 5.7.3.
-This is to ensure no incompatibilities between the terraform modules and old
-images that could be in the same family as a newer release. From now on, the
-image family includes the slurm-gcp major and minor version instead of the slurm
-version.
+> [!IMPORTANT]
+> The naming scheme for SchedMD published images has changed with release 5.7.3.
+> This is to ensure no incompatibilities between the terraform modules and old
+> images that could be in the same family as a newer release. From now on, the
+> image family includes the slurm-gcp major and minor version instead of the
+> slurm version.
 
 See [Images doc](./docs/images.md#published-image-family) for the latest
 published images.


### PR DESCRIPTION
Commit 87960d0866e0c8ae79c12a948d9974c080fef982 addresses failure of integration test from mdformat. It inadvertently introduced a known bug in mdformat:

https://github.com/executablebooks/mdformat/issues/359#issuecomment-1254998398

This PR swaps out mdformat for pymarkdown, which is already used in GoogleCloudPlatform/hpc-toolkit and re-formats the existing notices in line with pymarkdown. Future commits to README.md should pass linting tests.