### PR TITLE
Add prolog epilog tools

### DIFF
--- a/terraform/slurm_cluster/modules/slurm_controller_instance/README.md
+++ b/terraform/slurm_cluster/modules/slurm_controller_instance/README.md
@@ -38,6 +38,9 @@ The controller instance run [slurmctld](../../../../docs/glossary.md#slurmctld),
 See [examples](../../examples/slurm_controller_instance/) directory for sample
 usages.
 
+For further details on the [enable_external_prolog_epilog][eepe] feature, please
+visit [prologs-epilogs](../../../../tools/prologs-epilogs/README.md).
+
 See below for a simple inclusion within your own terraform project.
 
 ```hcl
@@ -66,3 +69,5 @@ module "slurm_controller_instance" {
 
 For the terraform module API reference, please see
 [README_TF.md](./README_TF.md).
+
+[eepe]: README_TF.md#input_enable_external_prolog_epilog

--- a/tools/prologs-epilogs/README.md
+++ b/tools/prologs-epilogs/README.md
@@ -1,0 +1,29 @@
+# Prologs and Epilogs
+
+The following scripts function simultaneously as both prolog and epilog scripts
+when used with the [external epilog and prolog][epe] feature of the
+slurm_controller_instance module.
+
+A typical approach is to stage these files to `/opt/apps/adm/slurm/scripts/` on
+the controller and then use symbolic links pointing from the directories that
+are iterated over by the `slurm_mux` external epilog and prolog feature.
+
+For example, if the following symbolic links are created:
+
+```
+/opt/apps/adm/slurm/prolog_slurmd.d/start-rxdm.prolog_slurmd -> ../scripts/receive-data-path-manager
+/opt/apps/adm/slurm/epilog_slurmd.d/stop-rxdm.epilog_slurmd -> ../scripts/receive-data-path-manager
+```
+
+Then the Receive Data Path Manager (RxDM) will be started before every user's
+job and stopped upon job exit, whether successful or failed. They can otherwise
+be run on a partition by partition basis, if they are placed in
+partition-specific directories. In the example below, the partition is named
+"a3":
+
+```
+/opt/apps/adm/slurm/partition-a3-prolog_slurmd.d/start-rxdm.prolog_slurmd -> ../scripts/receive-data-path-manager
+/opt/apps/adm/slurm/partition-a3-epilog_slurmd.d/stop-rxdm.epilog_slurmd -> ../scripts/receive-data-path-manager
+```
+
+[epe]: ../../terraform/slurm_cluster/modules/slurm_controller_instance/README_TF.md#input_enable_external_prolog_epilog

--- a/tools/prologs-epilogs/receive-data-path-manager
+++ b/tools/prologs-epilogs/receive-data-path-manager
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# do not invoke RxDM on non-A3 machines
+/usr/bin/curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/machine-type | grep -q "/a3-highgpu-8g$"
+IS_A3=$?
+if [[ "${IS_A3}" -ne 0 ]]; then
+	exit 0
+fi
+
+# do not invoke RxDM on 1-node jobs
+if [[ "${SLURM_JOB_NUM_NODES}" -eq 1 ]]; then
+	exit 0
+fi
+
+# path at which RxDM sockets will be created
+UDS_PATH="/run/tcpx-${SLURM_JOB_ID}"
+
+RXDM_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpx/tcpgpudmarxd-dev:v2.0.9
+if [[ ${SLURM_SCRIPT_CONTEXT} == "prolog_slurmd" ]]; then
+	# Install the TCPX NCCL Plugin
+	docker run --rm -v /var/lib:/var/lib \
+		us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpx/nccl-plugin-gpudirecttcpx-dev:v3.1.7 install
+
+	# Start TCPX receive-datapath-manager
+	GPU_NIC_TOPOLOGY=/opt/tcpdirect_benchmark/gpu_rxq_configuration.textproto
+	GPU_NIC_TOPOLOGY_DIR=$(dirname ${GPU_NIC_TOPOLOGY})
+	if [ ! -f "${GPU_NIC_TOPOLOGY}" ]; then
+		echo "GPU_NIC_TOPOLOGY file ${GPU_NIC_TOPOLOGY} must exist!"
+		exit 1
+	fi
+
+	docker run \
+		--pull=always \
+		--detach \
+		--rm \
+		--name receive-datapath-manager-"${SLURM_JOB_ID}" \
+		--cap-add=NET_ADMIN \
+		--network=host \
+		--privileged \
+		--gpus all \
+		--volume /var/lib/nvidia/lib64:/usr/local/nvidia/lib64 \
+		--volume "${GPU_NIC_TOPOLOGY_DIR}":"${GPU_NIC_TOPOLOGY_DIR}" \
+		--volume "${UDS_PATH}":"${UDS_PATH}" \
+		--env LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/run/tcpx:/usr/lib/lib32:/usr/lib/x86_64-linux-gnu/ \
+		--entrypoint /tcpgpudmarxd/build/app/tcpgpudmarxd \
+		${RXDM_IMAGE} \
+		--gpu_nic_preset manual \
+		--gpu_nic_topology ${GPU_NIC_TOPOLOGY} \
+		--gpu_shmem_type fd \
+		--uds_path "${UDS_PATH}"
+
+	# Give some time for tcpgpudmarxd to come up
+	sleep 10s
+
+elif [[ ${SLURM_SCRIPT_CONTEXT} == "epilog_slurmd" ]]; then
+	# Shut down rxdm container
+	docker container list --filter "name=receive-datapath-manager-${SLURM_JOB_ID}" --quiet | xargs --no-run-if-empty docker container stop
+	docker container prune --force
+	rm -rf "${UDS_PATH}"
+fi


### PR DESCRIPTION
This PR is blocked by #50 but may be useful while reviewing #50.

This PR adds 2 example scripts used by the automated prolog/epilog solution implemented in #50. The expectation, for now, is that  HPC Toolkit blueprints will clone this repo or use cURL to download "raw" GitHub URLs and place the files in appropriate directories.