### PR TITLE
Added decorator to retry gethostbyname in case of temporary DNS issues

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -24,7 +24,6 @@ import subprocess
 import sys
 import stat
 import time
-import socket
 from collections import defaultdict
 from concurrent.futures import as_completed
 from functools import partialmethod, lru_cache
@@ -712,7 +711,7 @@ def partition_mounts(mounts):
     def internal_mount(mount):
         # NOTE: Valid Lustre server_ip can take the form of '<IP>@tcp'
         server_ip = mount.server_ip.split("@")[0]
-        mount_addr = socket.gethostbyname(server_ip)
+        mount_addr = util.host_lookup(server_ip)
         return mount_addr == lkp.control_host_addr
 
     return separate(internal_mount, mounts)

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -32,7 +32,7 @@ import tempfile
 from collections import defaultdict, namedtuple
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
-from functools import lru_cache, reduce, partialmethod
+from functools import lru_cache, reduce, partialmethod, wraps
 from itertools import chain, compress, islice
 from pathlib import Path
 from time import sleep, time
@@ -701,6 +701,44 @@ def cached_property(f):
     return property(lru_cache()(f))
 
 
+def retry(max_retries: int, init_wait_time: float, warn_msg: str, exc_type: Exception):
+    """Retries functions that raises the exception exc_type.
+    Retry time is increased by a factor of two for every iteration.
+
+    Args:
+        max_retries (int): Maximum number of retries
+        init_wait_time (float): Initial wait time in secs
+        warn_msg (str): Message to print during retries
+        exc_type (Exception): Exception type to check for
+    """
+
+    if max_retries <= 0:
+        raise ValueError("Incorrect value for max_retries, must be >= 1")
+    if init_wait_time <= 0.0:
+        raise ValueError("Invalid value for init_wait_time, must be > 0.0")
+
+    def decorator(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            retry = 0
+            secs = init_wait_time
+            captured_exc = None
+            while retry < max_retries:
+                try:
+                    return f(*args, **kwargs)
+                except exc_type as e:
+                    captured_exc = e
+                    log.warn(f"{warn_msg}, retrying in {secs}")
+                    sleep(secs)
+                    retry += 1
+                    secs *= 2
+            raise captured_exc
+
+        return wrapper
+
+    return decorator
+
+
 def separate(pred, coll):
     """filter into 2 lists based on pred returning True or False
     returns ([False], [True])
@@ -1127,6 +1165,16 @@ def getThreadsPerCore(template):
         return 2
 
 
+@retry(
+    max_retries=9,
+    init_wait_time=1,
+    warn_msg="Temporary failure in name resolution",
+    exc_type=socket.gaierror,
+)
+def host_lookup(host_name: str) -> str:
+    return socket.gethostbyname(host_name)
+
+
 class Dumper(yaml.SafeDumper):
     """Add representers for pathlib.Path and NSDict for yaml serialization"""
 
@@ -1182,7 +1230,7 @@ class Lookup:
 
     @cached_property
     def control_host_addr(self):
-        return socket.gethostbyname(self.cfg.slurm_control_host)
+        return host_lookup(self.cfg.slurm_control_host)
 
     @property
     def control_host_port(self):


### PR DESCRIPTION
When multiple NICs are used on a Google Cloud VM, the startup-script begins executing shortly after the 1st NIC becomes online (routable). On Ubuntu 20.04, there is a local daemon offering DNS caching services that serves as the primary DNS server. This daemon restarts as each additional NIC after the first becomes online. This leads to extremely short intervals where DNS resolution fails on Ubuntu 20.04.

This PR implements a retry mechanism to a DNS lookup that occurs early in the Slurm startup-script and sometimes fails due to the above circumstances. It was tested on a 16-node cluster known to exhibit this problem. 14 of the 16 nodes booted without any issue, the remaining 2 retried the DNS lookup and succeeded on the 2nd try:

```
startup-script: WARNING: Temporary failure in name resolution, retrying in 1
```