### PR TITLE
Add PMIx support by default in v5

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -29,6 +29,7 @@
     install_ompi: true
     install_lustre: true
     install_gcsfuse: true
+    install_pmix: true
 
   pre_tasks:
   - name: Supported OS Check
@@ -76,6 +77,8 @@
     when:
     - install_cuda
     - ansible_architecture == "x86_64"
+  - role: pmix
+    when: install_pmix
   - nfs
   - cgroups
   - munge

--- a/ansible/roles/pmix/tasks/main.yml
+++ b/ansible/roles/pmix/tasks/main.yml
@@ -1,0 +1,41 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: Include OS Family Dependent Vars
+  ansible.builtin.include_vars: '{{ item }}'
+  with_first_found:
+  - '{{ ansible_distribution|lower }}-{{ ansible_distribution_version }}.yml'
+  - '{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version }}.yml'
+  - '{{ ansible_distribution|lower }}.yml'
+  - '{{ ansible_os_family|lower }}-{{ ansible_distribution_version }}.yml'
+  - '{{ ansible_os_family|lower }}-{{ ansible_distribution_major_version }}.yml'
+  - '{{ ansible_os_family|lower }}.yml'
+
+- name: Wait for DPKG Locks
+  ansible.builtin.shell: >
+    while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do
+      sleep 5
+    done
+  with_items:
+  - lock
+  - lock-frontend
+  when:
+  - ansible_os_family == 'Debian'
+
+- name: Install PMIx libraries and headers
+  ansible.builtin.package:
+    name: '{{ pmix_packages }}'
+    state: present

--- a/ansible/roles/pmix/vars/debian-10.yml
+++ b/ansible/roles/pmix/vars/debian-10.yml
@@ -1,0 +1,18 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+pmix_packages:
+- libpmix-dev

--- a/ansible/roles/pmix/vars/debian-11.yml
+++ b/ansible/roles/pmix/vars/debian-11.yml
@@ -1,0 +1,19 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+pmix_packages:
+- libpmix-dev
+- libpmix-bin

--- a/ansible/roles/pmix/vars/debian-12.yml
+++ b/ansible/roles/pmix/vars/debian-12.yml
@@ -1,0 +1,19 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+pmix_packages:
+- libpmix-dev
+- libpmix-bin

--- a/ansible/roles/pmix/vars/redhat-7.yml
+++ b/ansible/roles/pmix/vars/redhat-7.yml
@@ -1,0 +1,18 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+pmix_packages:
+- pmix-devel

--- a/ansible/roles/pmix/vars/redhat-8.yml
+++ b/ansible/roles/pmix/vars/redhat-8.yml
@@ -1,0 +1,18 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+pmix_packages:
+- pmix-devel

--- a/ansible/roles/pmix/vars/ubuntu-20.04.yml
+++ b/ansible/roles/pmix/vars/ubuntu-20.04.yml
@@ -1,0 +1,18 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+pmix_packages:
+- libpmix-dev

--- a/ansible/roles/pmix/vars/ubuntu-22.04.yml
+++ b/ansible/roles/pmix/vars/ubuntu-22.04.yml
@@ -1,0 +1,18 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+pmix_packages:
+- libpmix-dev


### PR DESCRIPTION
This commit installs PMIx development and binary libraries by default on our supported platforms. In testing, it was clear that adding "--with-pmix" to the configure flags was more fragile than just letting the configure script find pmix itself. We anticipate that, in Slurm 23.11, we will have to add this flag when PMIx installation is requested.

This was tested using the HPC Toolkit and 2 blueprints, 1 running Ubuntu 20.04 and the other running Rocky Linux 8. They showed:

## Ubuntu 20.04
```
$ srun --mpi=list
MPI plugin types are...
	pmi2
	none
	pmix
	cray_shasta
specific pmix plugin versions available: pmix_v3
```

## Rocky Linux 8
```
$ srun --mpi=list
MPI plugin types are...
	cray_shasta
	none
	pmi2
	pmix
specific pmix plugin versions available: pmix_v2
```