### PR TITLE
Add pmix to V6

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -78,7 +78,8 @@
     - install_cuda
     - ansible_architecture == "x86_64"
   - role: pmix
-    when: install_pmix
+    when:
+    - install_pmix
   - nfs
   - cgroups
   - munge

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -29,6 +29,7 @@
     install_ompi: true
     install_lustre: true
     install_gcsfuse: true
+    install_pmix: true
 
   pre_tasks:
   - name: Supported OS Check
@@ -76,6 +77,8 @@
     when:
     - install_cuda
     - ansible_architecture == "x86_64"
+  - role: pmix
+    when: install_pmix
   - nfs
   - cgroups
   - munge

--- a/ansible/roles/pmix/defaults/main.yaml
+++ b/ansible/roles/pmix/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+
+pmix_packages:

--- a/ansible/roles/pmix/tasks/main.yaml
+++ b/ansible/roles/pmix/tasks/main.yaml
@@ -1,14 +1,22 @@
 ---
 
+- name: Check PMIx OS Compatibility
+  assert:
+    that: not ( install_pmix and ansible_distribution == "CentOS" and ansible_distribution_major_version|int
+      <= 7 )
+    msg: PMIx is not available on CentOS 7
+
 - name: Include OS Family Dependent Vars
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
-  - '{{ ansible_distribution|lower }}-{{ ansible_distribution_version }}.yml'
-  - '{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version }}.yml'
-  - '{{ ansible_distribution|lower }}.yml'
-  - '{{ ansible_os_family|lower }}-{{ ansible_distribution_version }}.yml'
-  - '{{ ansible_os_family|lower }}-{{ ansible_distribution_major_version }}.yml'
-  - '{{ ansible_os_family|lower }}.yml'
+  - files:
+    - '{{ ansible_distribution|lower }}-{{ ansible_distribution_version }}.yml'
+    - '{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version }}.yml'
+    - '{{ ansible_distribution|lower }}.yml'
+    - '{{ ansible_os_family|lower }}-{{ ansible_distribution_version }}.yml'
+    - '{{ ansible_os_family|lower }}-{{ ansible_distribution_major_version }}.yml'
+    - '{{ ansible_os_family|lower }}.yml'
+    skip: true
 
 - name: Wait for DPKG Locks
   ansible.builtin.shell: >

--- a/ansible/roles/pmix/tasks/main.yaml
+++ b/ansible/roles/pmix/tasks/main.yaml
@@ -1,0 +1,27 @@
+---
+
+- name: Include OS Family Dependent Vars
+  ansible.builtin.include_vars: '{{ item }}'
+  with_first_found:
+  - '{{ ansible_distribution|lower }}-{{ ansible_distribution_version }}.yml'
+  - '{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version }}.yml'
+  - '{{ ansible_distribution|lower }}.yml'
+  - '{{ ansible_os_family|lower }}-{{ ansible_distribution_version }}.yml'
+  - '{{ ansible_os_family|lower }}-{{ ansible_distribution_major_version }}.yml'
+  - '{{ ansible_os_family|lower }}.yml'
+
+- name: Wait for DPKG Locks
+  ansible.builtin.shell: >
+    while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do
+      sleep 5
+    done
+  with_items:
+  - lock
+  - lock-frontend
+  when:
+  - ansible_os_family == 'Debian'
+
+- name: Install PMIx libraries and headers
+  ansible.builtin.package:
+    name: '{{ pmix_packages }}'
+    state: present

--- a/ansible/roles/pmix/vars/debian-10.yml
+++ b/ansible/roles/pmix/vars/debian-10.yml
@@ -1,0 +1,4 @@
+---
+
+pmix_packages:
+- libpmix-dev

--- a/ansible/roles/pmix/vars/debian-11.yml
+++ b/ansible/roles/pmix/vars/debian-11.yml
@@ -1,0 +1,5 @@
+---
+
+pmix_packages:
+- libpmix-dev
+- libpmix-bin

--- a/ansible/roles/pmix/vars/debian-12.yml
+++ b/ansible/roles/pmix/vars/debian-12.yml
@@ -1,0 +1,5 @@
+---
+
+pmix_packages:
+- libpmix-dev
+- libpmix-bin

--- a/ansible/roles/pmix/vars/redhat-8.yml
+++ b/ansible/roles/pmix/vars/redhat-8.yml
@@ -1,0 +1,4 @@
+---
+
+pmix_packages:
+- pmix-devel

--- a/ansible/roles/pmix/vars/ubuntu-20.04.yml
+++ b/ansible/roles/pmix/vars/ubuntu-20.04.yml
@@ -1,0 +1,4 @@
+---
+
+pmix_packages:
+- libpmix-dev

--- a/ansible/roles/pmix/vars/ubuntu-22.04.yml
+++ b/ansible/roles/pmix/vars/ubuntu-22.04.yml
@@ -1,0 +1,4 @@
+---
+
+pmix_packages:
+- libpmix-dev

--- a/ansible/roles/slurm/tasks/install.yml
+++ b/ansible/roles/slurm/tasks/install.yml
@@ -50,6 +50,9 @@
       {{slurm_paths.src}}/configure
       --prefix={{slurm_paths.install}}
       --sysconfdir={{slurm_paths.etc}}
+      {% if install_pmix -%}
+      --with-pmix
+      {% endif -%}
       --with-jwt={{slurm_paths.install}}
       --with-systemdsystemunitdir=/usr/lib/systemd/system/
       > /dev/null


### PR DESCRIPTION
This PR adds the `install_pmix` flag to the ansible playbook to incorporate PMIx with default installations.  It is only available for Debian 10-12, Redhat/Rocky 8, and Ubuntu 20 and 22.  CentOS will install but will not use the `--with-pmix` flag during Slurm installation.

This was tested using an HPC Toolkit blueprint to use packer to build Rocky 8, Debian 11, Ubuntu 20 and 22, and Centos 7.  

Using `srun --mpi=list` it was observed that Rocky 8 had pmix installed, and Centos 7 threw an assertion error as expected.  

The Debian and Ubuntu images all had pmix installed correctly for Slurm.