### PR TITLE
Updating v5 branch to use source to install pmix so CentOS works

### DIFF
--- a/ansible/roles/pmix/defaults/main.yaml
+++ b/ansible/roles/pmix/defaults/main.yaml
@@ -1,0 +1,6 @@
+---
+
+pmix_version: 4.2.9
+sha1_v429: 912c70f567098dd0a7c0a03a816c5e6ecfaf1962
+# This is set separate from path.installation as slurm searches /usr and /usr/local for pmix
+pmix_installation_path: /usr/local

--- a/ansible/roles/pmix/defaults/main.yaml
+++ b/ansible/roles/pmix/defaults/main.yaml
@@ -1,6 +1,9 @@
 ---
 
 pmix_version: 4.2.9
-sha1_v429: 912c70f567098dd0a7c0a03a816c5e6ecfaf1962
+pmix_dir: pmix-{{ pmix_version }}
+pmix_tar: '{{ pmix_dir }}.tar.gz'
+pmix_url: https://github.com/openpmix/openpmix/releases/download/v{{ pmix_version
+  }}/{{ pmix_tar }}
 # This is set separate from path.installation as slurm searches /usr and /usr/local for pmix
 pmix_installation_path: /usr/local

--- a/ansible/roles/pmix/tasks/main.yml
+++ b/ansible/roles/pmix/tasks/main.yml
@@ -35,7 +35,25 @@
   when:
   - ansible_os_family == 'Debian'
 
-- name: Install PMIx libraries and headers
+- name: Install PMIx dependencies
   ansible.builtin.package:
-    name: '{{ pmix_packages }}'
+    name: '{{ pmix_dependencies }}'
     state: present
+
+- name: Download PMIX
+  ansible.builtin.get_url:
+    url: https://github.com/openpmix/openpmix/releases/download/v{{ pmix_version }}/pmix-{{
+      pmix_version }}.tar.gz
+    dest: /tmp/pmix-{{ pmix_version }}.tar.gz
+    checksum: sha1:{{ sha1_v429 }}
+
+- name: Build PMIx
+  ansible.builtin.shell: |
+    cd /tmp
+    tar xzf pmix-{{ pmix_version }}.tar.gz
+    cd pmix-{{ pmix_version }}
+    ./configure --prefix={{ pmix_installation_path }} >> conf.txt
+    make -j {{ ansible_processor_vcpus }} all >> make_res.txt
+    make install
+  args:
+    creates: '{{ pmix_installation_path }}/lib/libpmix.so'

--- a/ansible/roles/pmix/tasks/main.yml
+++ b/ansible/roles/pmix/tasks/main.yml
@@ -42,18 +42,16 @@
 
 - name: Download PMIX
   ansible.builtin.get_url:
-    url: https://github.com/openpmix/openpmix/releases/download/v{{ pmix_version }}/pmix-{{
-      pmix_version }}.tar.gz
-    dest: /tmp/pmix-{{ pmix_version }}.tar.gz
-    checksum: sha1:{{ sha1_v429 }}
+    url: '{{ pmix_url }}'
+    dest: '{{ paths.build }}/{{ pmix_tar }}'
 
 - name: Build PMIx
   ansible.builtin.shell: |
-    cd /tmp
-    tar xzf pmix-{{ pmix_version }}.tar.gz
-    cd pmix-{{ pmix_version }}
-    ./configure --prefix={{ pmix_installation_path }} >> conf.txt
-    make -j {{ ansible_processor_vcpus }} all >> make_res.txt
+    cd {{ paths.build }}
+    tar xzf {{ pmix_tar }}
+    cd {{ pmix_dir }}
+    ./configure --prefix={{ pmix_installation_path }} > /dev/null
+    make -j {{ ansible_processor_vcpus }} all > /dev/null
     make install
   args:
     creates: '{{ pmix_installation_path }}/lib/libpmix.so'

--- a/ansible/roles/pmix/vars/debian-10.yml
+++ b/ansible/roles/pmix/vars/debian-10.yml
@@ -14,5 +14,6 @@
 
 ---
 
-pmix_packages:
-- libpmix-dev
+pmix_dependencies:
+- libevent-dev
+- libhwloc-dev

--- a/ansible/roles/pmix/vars/debian-11.yml
+++ b/ansible/roles/pmix/vars/debian-11.yml
@@ -14,6 +14,6 @@
 
 ---
 
-pmix_packages:
-- libpmix-dev
-- libpmix-bin
+pmix_dependencies:
+- libevent-dev
+- libhwloc-dev

--- a/ansible/roles/pmix/vars/debian-12.yml
+++ b/ansible/roles/pmix/vars/debian-12.yml
@@ -14,6 +14,6 @@
 
 ---
 
-pmix_packages:
-- libpmix-dev
-- libpmix-bin
+pmix_dependencies:
+- libevent-dev
+- libhwloc-dev

--- a/ansible/roles/pmix/vars/redhat-7.yml
+++ b/ansible/roles/pmix/vars/redhat-7.yml
@@ -14,5 +14,6 @@
 
 ---
 
-pmix_packages:
-- pmix-devel
+pmix_dependencies:
+- libevent-devel
+- hwloc-devel

--- a/ansible/roles/pmix/vars/redhat-8.yml
+++ b/ansible/roles/pmix/vars/redhat-8.yml
@@ -14,5 +14,6 @@
 
 ---
 
-pmix_packages:
-- pmix-devel
+pmix_dependencies:
+- libevent-devel
+- hwloc-devel

--- a/ansible/roles/pmix/vars/ubuntu-20.04.yml
+++ b/ansible/roles/pmix/vars/ubuntu-20.04.yml
@@ -14,5 +14,6 @@
 
 ---
 
-pmix_packages:
-- libpmix-dev
+pmix_dependencies:
+- libevent-dev
+- libhwloc-dev

--- a/ansible/roles/pmix/vars/ubuntu-22.04.yml
+++ b/ansible/roles/pmix/vars/ubuntu-22.04.yml
@@ -14,5 +14,6 @@
 
 ---
 
-pmix_packages:
-- libpmix-dev
+pmix_dependencies:
+- libevent-dev
+- libhwloc-dev


### PR DESCRIPTION
This is an update to the previous PR to install pmix, but instead of using a package manager, it uses the source.  CentOS 7 doesn't have pmix v2+ which is required for slurm if pmix is to be installed.  

This is based on the v6 PR for pmix.

Tested by building a CentOS 7 image, deploying a controller, and checking the mpi modules with the command `srun --mpi=list`, the result was seeing pmix v4 installed.