### PR TITLE
Adopt Google yamlfmt pre-commit hook

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,11 +1,11 @@
 ---
 workflow:
   rules:
-    # skip pipeline if the source is a tag
+  # skip pipeline if the source is a tag
   - if: $CI_COMMIT_TAG
     when: never
-      # Skip pipeline on merge request event
-      # TODO this should be possible, but I'm not sure how it works yet
+    # Skip pipeline on merge request event
+    # TODO this should be possible, but I'm not sure how it works yet
   - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     when: never
   - when: always

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,15 +33,10 @@ repos:
     # in line with its expectations
     exclude_types:
     - markdown
-- repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
-  rev: 0.2.3
+- repo: https://github.com/google/yamlfmt
+  rev: v0.11.0
   hooks:
   - id: yamlfmt
-    args:
-    - --mapping=2
-    - --sequence=2
-    - --offset=0
-    - --width=80
 - repo: local
   hooks:
   - id: packer_fmt
@@ -73,7 +68,6 @@ repos:
   hooks:
   - id: flake8
     exclude: ^dm/
-
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.5
   hooks:

--- a/.yamlfmt
+++ b/.yamlfmt
@@ -1,0 +1,6 @@
+---
+formatter:
+  include_document_start: true
+  indentless_arrays: true
+  retain_line_breaks_single: true
+  scan_folded_as_literal: true

--- a/ansible/roles/common/tasks/os/redhat-7.yml
+++ b/ansible/roles/common/tasks/os/redhat-7.yml
@@ -13,8 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Upgrade {{ ansible_os_family }}-{{ ansible_distribution_major_version }} Family
-    System Software
+- name: Upgrade {{ ansible_os_family }}-{{ ansible_distribution_major_version }} Family System Software
   yum:
     name: '*'
     state: latest

--- a/ansible/roles/common/tasks/os/redhat-8.yml
+++ b/ansible/roles/common/tasks/os/redhat-8.yml
@@ -13,8 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Upgrade {{ ansible_os_family }}-{{ ansible_distribution_major_version }} Family
-    System Software
+- name: Upgrade {{ ansible_os_family }}-{{ ansible_distribution_major_version }} Family System Software
   yum:
     # name: '*'
     # state: latest

--- a/ansible/roles/gcsfuse/tasks/os/debian.yml
+++ b/ansible/roles/gcsfuse/tasks/os/debian.yml
@@ -20,8 +20,7 @@
 
 - name: Add Gcsfuse Repository
   apt_repository:
-    repo: deb https://packages.cloud.google.com/apt gcsfuse-{{ansible_distribution_release}}
-      main
+    repo: deb https://packages.cloud.google.com/apt gcsfuse-{{ansible_distribution_release}} main
     filename: gcsfuse
     update_cache: yes
     state: present

--- a/ansible/roles/lmod/tasks/main.yml
+++ b/ansible/roles/lmod/tasks/main.yml
@@ -64,5 +64,5 @@
     state: link
   with_items:
   - {src: '{{lmod_paths.build}}/init/profile', dest: /etc/profile.d/z00_lmod.sh}
-  - {src: '{{lmod_paths.build}}/init/cshrc', dest: /etc/profile.d/z00_lmod.csh}
-    # - { src: "{{lmod_paths.build}}/init/profile.fish", dest: "/etc/fish/conf.d/z00_lmod.fish" }
+  - {src: '{{lmod_paths.build}}/init/cshrc', dest: /etc/profile.d/z00_lmod.csh,}
+  # - { src: "{{lmod_paths.build}}/init/profile.fish", dest: "/etc/fish/conf.d/z00_lmod.fish" }

--- a/ansible/roles/mariadb/tasks/os/debian.yml
+++ b/ansible/roles/mariadb/tasks/os/debian.yml
@@ -19,7 +19,6 @@
     - libmariadb-dev
     state: present
 
-
 - name: Install {{ansible_os_family}} Family Server
   apt:
     name:

--- a/ansible/roles/motd/tasks/main.yml
+++ b/ansible/roles/motd/tasks/main.yml
@@ -26,6 +26,5 @@
 - name: Add Warning
   ansible.builtin.lineinfile:
     path: /etc/motd
-    line: "*** Slurm instance has not been set up yet. Did the startup-script run?\
-      \ ***\n"
+    line: "*** Slurm instance has not been set up yet. Did the startup-script run? ***\n"
     insertafter: EOF

--- a/ansible/roles/tpu/tasks/main.yml
+++ b/ansible/roles/tpu/tasks/main.yml
@@ -21,8 +21,7 @@
 
 - name: Calculate python310 variable
   set_fact:
-    python310: "{{ tf_version.split('.')[1] | int >= 13 or (tf_version.split('.')[1]\
-      \ | int == 12 and tf_version.split('.')[2] | int >= 1) }}"
+    python310: "{{ tf_version.split('.')[1] | int >= 13 or (tf_version.split('.')[1] | int == 12 and tf_version.split('.')[2] | int >= 1) }}"
 
 - name: Generate wheel variable
   set_fact:

--- a/third_party/ansible/roles/cuda/.travis.yml
+++ b/third_party/ansible/roles/cuda/.travis.yml
@@ -11,8 +11,7 @@ cache:
   pip: true
 
 before_cache:
-- sudo mkdir $HOME/lxc && sudo tar cf $HOME/lxc/cache.tar /var/cache/lxc/ && sudo
-  chown $USER. $HOME/lxc/cache.tar
+- sudo mkdir $HOME/lxc && sudo tar cf $HOME/lxc/cache.tar /var/cache/lxc/ && sudo chown $USER. $HOME/lxc/cache.tar
 
 install:
 - sudo tar xf $HOME/lxc/cache.tar -C / || true
@@ -26,24 +25,21 @@ install:
 - ansible-playbook -vvv tests/install.yml -i tests/inventory
 
 script:
-  # Validates your deployment playbook's syntax, which should contain your role
+# Validates your deployment playbook's syntax, which should contain your role
 - ansible-playbook -i tests/inventory tests/deploy.yml --syntax-check
 
-  # Runs the deployment playbook
+# Runs the deployment playbook
 - ansible-playbook -i tests/inventory -v tests/deploy.yml
 
-  # Basic role syntax check
+# Basic role syntax check
 - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
 
-  # Perform a test run with the playbook
+# Perform a test run with the playbook
 - travis_wait ansible-playbook tests/test.yml -i tests/inventory
 
-  # Perform a another test run with the playbook to check for idempotency
-- unbuffer ansible-playbook tests/test.yml -i tests/inventory >/tmp/idempotency.log
-  2>&1
-- 'grep -A1 "PLAY RECAP" /tmp/idempotency.log | grep -qP "changed=0.*failed=0" &&
-  (echo "Idempotence: PASS"; exit 0) || (echo "Idempotence: FAIL"; cat /tmp/idempotency.log;
-  exit 1)'
+# Perform a another test run with the playbook to check for idempotency
+- unbuffer ansible-playbook tests/test.yml -i tests/inventory >/tmp/idempotency.log 2>&1
+- 'grep -A1 "PLAY RECAP" /tmp/idempotency.log | grep -qP "changed=0.*failed=0" && (echo "Idempotence: PASS"; exit 0) || (echo "Idempotence: FAIL"; cat /tmp/idempotency.log; exit 1)'
 
 notifications:
   email: false

--- a/third_party/ansible/roles/cuda/meta/main.yml
+++ b/third_party/ansible/roles/cuda/meta/main.yml
@@ -24,8 +24,8 @@ galaxy_info:
   platforms:
   - name: EL
     versions:
-  #  - all
-  #  - 5
+    #  - all
+    #  - 5
     - 7
     - 8
   #- name: GenericUNIX
@@ -81,15 +81,15 @@ galaxy_info:
   #  - 9.2
   - name: Ubuntu
     versions:
-  #  - all
-  #  - lucid
-  #  - maverick
-  #  - natty
-  #  - oneiric
-  #  - precise
-  #  - quantal
-  #  - raring
-  #  - saucy
+    #  - all
+    #  - lucid
+    #  - maverick
+    #  - natty
+    #  - oneiric
+    #  - precise
+    #  - quantal
+    #  - raring
+    #  - saucy
     - trusty
     - utopic
     - vivid
@@ -139,6 +139,6 @@ galaxy_info:
   - system
   #- web
 dependencies: []
-  # List your role dependencies here, one per line.
-  # Be sure to remove the '[]' above if you add dependencies
-  # to this list.
+# List your role dependencies here, one per line.
+# Be sure to remove the '[]' above if you add dependencies
+# to this list.

--- a/third_party/ansible/roles/cuda/tasks/configure_apt_cuda.yml
+++ b/third_party/ansible/roles/cuda/tasks/configure_apt_cuda.yml
@@ -15,7 +15,6 @@
     name: dkms
     selection: hold
 
-
 - name: lookup cuda driver version
   shell: |
     apt-cache madison cuda-drivers | awk '{print $3}' | sort -r | while read line; do

--- a/third_party/ansible/roles/cuda/tasks/install_runfile.yml
+++ b/third_party/ansible/roles/cuda/tasks/install_runfile.yml
@@ -11,8 +11,7 @@
 
 - name: Determine kernel version
   set_fact:
-    cuda_driver_kernel_version: '{{ cuda_driver_kernel_version | default(cuda_driver_kernel_running.stdout,
-      true) }}'
+    cuda_driver_kernel_version: '{{ cuda_driver_kernel_version | default(cuda_driver_kernel_running.stdout, true) }}'
 
 - name: Ensure kernel headers are installed (yum)
   yum:
@@ -58,8 +57,7 @@
   set_fact:
     cuda_driver_installed: '{{ cuda_driver_kernel_module_find.matched > 0 }}'
     cuda_toolkit_installed: '{{ cuda_toolkit_path.stat.exists }}'
-    cuda_runfile_checksum_url: "{{ cuda_runfile_checksum_url | default(cuda_runfile_url\
-      \ | regex_replace('local_installers/.*', 'docs/sidebar/md5sum.txt'), true) }}"
+    cuda_runfile_checksum_url: "{{ cuda_runfile_checksum_url | default(cuda_runfile_url | regex_replace('local_installers/.*', 'docs/sidebar/md5sum.txt'), true) }}"
 
 - name: Print information about installed features
   debug:
@@ -91,10 +89,8 @@
 
 - name: Get checksums from dict
   set_fact:
-    cuda_runfile_valid_checksum: '{{checksums.dict[ cuda_runfile_sh ].checksum}} ==
-      cuda_runtime_file.stat.checksum'
+    cuda_runfile_valid_checksum: '{{checksums.dict[ cuda_runfile_sh ].checksum}} == cuda_runtime_file.stat.checksum'
   when: cuda_runtime_file.stat.exists
-
 
 - name: Obtain runfile
   block:
@@ -116,9 +112,7 @@
       dest: /tmp/cuda_runfile/{{ cuda_runfile_sh }}
     when: cuda_runfile_download
 
-  when: not (cuda_runtime_file.stat.exists and cuda_runfile_valid_checksum) and ((cuda_runfile_toolkit
-    and not cuda_toolkit_installed) or (cuda_runfile_driver and not cuda_driver_installed))
-
+  when: not (cuda_runtime_file.stat.exists and cuda_runfile_valid_checksum) and ((cuda_runfile_toolkit and not cuda_toolkit_installed) or (cuda_runfile_driver and not cuda_driver_installed))
 
 - name: Run installer for toolkit
   command: bash /tmp/cuda_runfile/{{ cuda_runfile_sh }} --silent --toolkit
@@ -150,8 +144,7 @@
 
   - name: Print information about driver
     debug:
-      msg: Building driver {{ cuda_driver_runfile }} for kernel {{ cuda_driver_kernel_version
-        }}
+      msg: Building driver {{ cuda_driver_runfile }} for kernel {{ cuda_driver_kernel_version }}
 
   - name: Install driver
     command: >

--- a/third_party/ansible/roles/cuda/tasks/main.yml
+++ b/third_party/ansible/roles/cuda/tasks/main.yml
@@ -25,8 +25,7 @@
   - include_tasks: install_runfile.yml
     when: cuda_use_runfile
 
-  - name: Install CUDA packages (1.5-2GB download, also restarts if cuda_restart_node_on_install
-      is set to True)
+  - name: Install CUDA packages (1.5-2GB download, also restarts if cuda_restart_node_on_install is set to True)
     package:
       name: '{{ item }}'
       state: fixed

--- a/third_party/ansible/roles/cuda/tests/install.yml
+++ b/third_party/ansible/roles/cuda/tests/install.yml
@@ -9,11 +9,10 @@
     - profile: centos-7
     - profile: ubuntu-bionic
 
-
 # Run the following within the containers in the inventory
 - hosts: all
   tasks:
-    # Solution for avahi-daemon issue from https://github.com/lxc/lxc/issues/25
+  # Solution for avahi-daemon issue from https://github.com/lxc/lxc/issues/25
   - block:
     - name: Install avahi-daemon early on Ubuntu 16 containers
       package:


### PR DESCRIPTION
This copy of yamlfmt respects licenses at the beginning of YAML files that Google contributions are required to have. The old copy of yamlfmt does not. Running this hook (and yamlfmt) configuration against all files creates changes in 14 files which appear to be:

- fixing indentation of comments (harmless)
- taking strings that were split across lines and making them appear on one line

We have encountered cases where the old yamlfmt hook wrongly and harmfully split YAML/jinja strings across lines (1cd5a03a) so these changes are probably good but need to be tested.

I am manually testing the image building process and will report in a follow-up comment.