### PR TITLE
Hold back marking a node as orphan if it was created in the last 90 sec

### DIFF
--- a/scripts/slurmsync.py
+++ b/scripts/slurmsync.py
@@ -226,9 +226,9 @@ def find_node_status(nodename):
             return NodeStatus.terminated
     elif (state is None or "POWERED_DOWN" in state.flags) and inst.status == "RUNNING":
         log.info("%s is potential orphan node", nodename)
-        log.info("%s state: %s", nodename, state)
         age_threshold_seconds = 90
         inst_seconds_old = _seconds_since_timestamp(inst.creationTimestamp)
+        log.info("%s state: %s, age: %0.1fs", nodename, state, inst_seconds_old)
         if inst_seconds_old < age_threshold_seconds:
             log.info(
                 "%s not marked as orphan, it started less than %ds ago (%0.1fs)",

--- a/scripts/slurmsync.py
+++ b/scripts/slurmsync.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import argparse
+import datetime
 import fcntl
 import hashlib
 import json
@@ -224,12 +225,37 @@ def find_node_status(nodename):
         if not state.base.startswith("DOWN"):
             return NodeStatus.terminated
     elif (state is None or "POWERED_DOWN" in state.flags) and inst.status == "RUNNING":
+        log.info("%s is potential orphan node", nodename)
+        log.info("%s state: %s", nodename, state)
+        age_threshold_seconds = 90
+        inst_seconds_old = _seconds_since_timestamp(inst.creationTimestamp)
+        if inst_seconds_old < age_threshold_seconds:
+            log.info(
+                "%s not marked as orphan, it started less than %ds ago (%0.1fs)",
+                nodename,
+                age_threshold_seconds,
+                inst_seconds_old,
+            )
+            return NodeStatus.unchanged
         return NodeStatus.orphan
     elif state is None:
         # if state is None here, the instance exists but it's not in Slurm
         return NodeStatus.unknown
 
     return NodeStatus.unchanged
+
+
+def _seconds_since_timestamp(timestamp):
+    """Returns duration in seconds since a timestamp
+    Args:
+        timestamp: A formatted timestamp string (%Y-%m-%dT%H:%M:%S.%f%z)
+    Returns:
+        number of seconds that have past since the timestamp (float)
+    """
+    if timestamp[-3] == ":":  # python 36 datetime does not support the colon
+        timestamp = timestamp[:-3] + timestamp[-2:]
+    creation_dt = datetime.datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%f%z")
+    return datetime.datetime.now().timestamp() - creation_dt.timestamp()
 
 
 def do_node_update(status, nodes):


### PR DESCRIPTION
Same change as #54, but for Slurm GCP v6.

`slurmsync.py` bases decisions off of state from two different sources: GCP and Slurm controller. This separate of state makes a race condition possible where `slurmsync` marks a node as an orphan when it is actually coming up normally. Orphan state is: GCP node is running but Slurm node is powered down.

This change forestalls Slurm from marking a node as an orphan if it has recently been created (last 90s). In the rare case of the race condition described above, the 90s waiting period will allow for state to come into sync.

I have tested manually by deploying the code and forcing the orphan condition.