### PR TITLE
Refactor creation pub/sub client in multithreaded use

### DIFF
--- a/scripts/destroy_subscriptions.py
+++ b/scripts/destroy_subscriptions.py
@@ -18,10 +18,9 @@ import logging
 from pathlib import Path
 from util import (
     config_root_logger,
-    execute_with_futures,
     parse_self_link,
-    subscription_delete,
     subscription_list,
+    delete_subscriptions,
 )
 
 logger_name = Path(__file__).name
@@ -37,7 +36,7 @@ def main(args):
         )
     )
     subscriptions = [parse_self_link(s).subscription for s in subscriptions]
-    execute_with_futures(subscription_delete, subscriptions)
+    delete_subscriptions(subscriptions)
 
 
 if __name__ == "__main__":

--- a/scripts/resume.py
+++ b/scripts/resume.py
@@ -37,12 +37,11 @@ from util import (
     chunked,
     separate,
     batch_execute,
-    execute_with_futures,
     is_exclusive_node,
-    subscription_create,
     to_hostlist,
     trim_self_link,
     wait_for_operation,
+    create_subscriptions,
 )
 from util import cfg, lkp, NSDict
 
@@ -359,7 +358,7 @@ def resume_nodes(nodelist, placement_groups=None, exclusive_job=None):
         count = len(started_nodes)
         hostlist = util.to_hostlist(started_nodes)
         log.info("create {} subscriptions ({})".format(count, hostlist))
-        execute_with_futures(subscription_create, nodelist)
+        create_subscriptions(nodelist)
 
 
 def update_job_comment(nodelist, comment):

--- a/scripts/slurmsync.py
+++ b/scripts/slurmsync.py
@@ -27,14 +27,13 @@ import yaml
 
 import util
 from util import (
-    execute_with_futures,
     run,
     separate,
     batch_execute,
-    subscription_create,
-    subscription_delete,
     to_hostlist,
     with_static,
+    create_subscriptions,
+    delete_subscriptions,
 )
 from util import lkp, cfg, compute
 from suspend import delete_instances
@@ -323,12 +322,12 @@ def do_subscription_update(status, subscriptions):
     def subscriptions_create():
         """create subscriptions"""
         log.info("Creating {} subcriptions ({})".format(count, hostlist))
-        execute_with_futures(subscription_create, subscriptions)
+        create_subscriptions(subscriptions)
 
     def subscriptions_delete():
         """delete subscriptions"""
         log.info("Deleting {} subcriptions ({})".format(count, hostlist))
-        execute_with_futures(subscription_delete, subscriptions)
+        delete_subscriptions(subscriptions)
 
     update = dict.get(
         {

--- a/scripts/suspend.py
+++ b/scripts/suspend.py
@@ -26,14 +26,13 @@ from util import (
     groupby_unsorted,
     log_api_request,
     run,
-    execute_with_futures,
     batch_execute,
     ensure_execute,
-    subscription_delete,
     to_hostlist,
     wait_for_operations,
     separate,
     is_exclusive_node,
+    delete_subscriptions,
 )
 from util import lkp, cfg, compute
 
@@ -80,7 +79,7 @@ def delete_instances(instances):
     if lkp.cfg.enable_reconfigure:
         count = len(valid)
         log.info("delete {} subscriptions ({})".format(count, valid_hostlist))
-        execute_with_futures(subscription_delete, valid)
+        delete_subscriptions(valid)
 
     requests = {inst: delete_instance_request(inst) for inst in valid}
 

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -301,9 +301,12 @@ def subscription_list(project_id=None, page_size=None, slurm_cluster_name=None):
     return subscriptions
 
 
-def delete_subscriptions(seq):
+def delete_subscriptions(subscription_ids):
     """Deletes a list of subscriptions
     API calls are made in parallel from thread pool
+
+    Args:
+      subscription_ids: Iterable of strings containing subscription IDs
     """
     from google.cloud import pubsub_v1
 
@@ -312,8 +315,8 @@ def delete_subscriptions(seq):
     with subscriber:
         with ThreadPoolExecutor() as exe:
             futures = []
-            for i in seq:
-                future = exe.submit(_delete_subscription, i, subscriber)
+            for subscription_id in subscription_ids:
+                future = exe.submit(_delete_subscription, subscription_id, subscriber)
                 futures.append(future)
             for future in as_completed(futures):
                 result = future.exception()
@@ -334,9 +337,12 @@ def _delete_subscription(subscription_id, subscriber):
         log.info(f"Subscription '{subscription_path}' not found!")
 
 
-def create_subscriptions(seq):
+def create_subscriptions(subscription_ids):
     """Creates a list of subscriptions
     API calls are made in parallel from thread pool
+
+    Args:
+      subscription_ids: Iterable of strings containing subscription IDs
     """
     from google.cloud import pubsub_v1
 
@@ -346,8 +352,10 @@ def create_subscriptions(seq):
     with subscriber:
         with ThreadPoolExecutor() as exe:
             futures = []
-            for i in seq:
-                future = exe.submit(_create_subscription, i, publisher, subscriber)
+            for subscription_id in subscription_ids:
+                future = exe.submit(
+                    _create_subscription, subscription_id, publisher, subscriber
+                )
                 futures.append(future)
             for future in as_completed(futures):
                 result = future.exception()


### PR DESCRIPTION
This change avoids a case where creation of pub/sub client hangs when created simultaneously on multiple threads. Behavior was observed similar that described in [this bug](https://github.com/googleapis/python-pubsub/issues/1101). 

This change stops the practice of creating new pub/sub clients in each thread. Instead a single client is created and the passed into each thread where the api calls are made. 

`google-cloud-pubsub` python client documentation directly addresses multithreading/multiprocessing ([documentation](https://cloud.google.com/python/docs/reference/pubsub/2.18.4/multiprocessing)). It claims that _"it is safe to share instances across threads"_. The one caveat is that if multiprocessing is being used, the client should be created prior to the os.fork() call. In our case we are using multithreading (`ThreadPoolExecutor`), not multiprocessing (`ProcessPoolExecutor`). This is reasonable since we are performing I/O bound operations and not cpu bound. My understanding is that `ThreadPoolExecutor` does not call os.fork() as os.fork() is used to create new processes, not new threads.