### PR TITLE
Updating logging to include age of potential orphan node

### DIFF
--- a/scripts/slurmsync.py
+++ b/scripts/slurmsync.py
@@ -146,9 +146,9 @@ def find_node_status(nodename):
             return NodeStatus.terminated
     elif (state is None or "POWERED_DOWN" in state.flags) and inst.status == "RUNNING":
         log.info("%s is potential orphan node", nodename)
-        log.info("%s state: %s", nodename, state)
         age_threshold_seconds = 90
         inst_seconds_old = _seconds_since_timestamp(inst.creationTimestamp)
+        log.info("%s state: %s, age: %0.1fs", nodename, state, inst_seconds_old)
         if inst_seconds_old < age_threshold_seconds:
             log.info(
                 "%s not marked as orphan, it started less than %ds ago (%0.1fs)",


### PR DESCRIPTION
We're seeing issues where nodes are being declared orphans too quickly, so this additional logging gives us more information about the age of the nodes.