### PR TITLE
Support specifying monitoring agent in Packer

### DIFF
--- a/packer/main.pkr.hcl
+++ b/packer/main.pkr.hcl
@@ -25,12 +25,13 @@ locals {
   scripts_dir = "../scripts"
 
   ansible_vars = {
-    slurm_version   = var.slurm_version
-    install_cuda    = var.install_cuda
-    nvidia_version  = var.nvidia_version
-    install_ompi    = var.install_ompi
-    install_lustre  = var.install_lustre
-    install_gcsfuse = var.install_gcsfuse
+    slurm_version    = var.slurm_version
+    install_cuda     = var.install_cuda
+    nvidia_version   = var.nvidia_version
+    install_ompi     = var.install_ompi
+    install_lustre   = var.install_lustre
+    install_gcsfuse  = var.install_gcsfuse
+    monitoring_agent = var.monitoring_agent
   }
 
   parse_version = regex("^(?P<major>\\d+)(?:\\.(?P<minor>\\d+))?(?:\\.(?P<patch>\\d+))?|(?P<branch>\\w+)$", var.slurmgcp_version)

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -169,6 +169,17 @@ variable "install_gcsfuse" {
   default     = true
 }
 
+variable "monitoring_agent" {
+  description = "Select which agent to install"
+  type        = string
+  default     = "legacy"
+
+  validation {
+    condition     = contains(["cloud-ops", "legacy", "none"], var.monitoring_agent)
+    error_message = "Set var.monitoring_agent to \"cloud-ops\", \"legacy\", or \"none\"."
+  }
+}
+
 ######################
 # BUILD VM VARIABLES #
 ######################


### PR DESCRIPTION
#18 added the ability for Ansible code to select between the legacy and contemporary implementations for Cloud Monitoring and Cloud Logging agents. This PR exposes that setting via Packer.