### PR TITLE
Add support for installing NVIDIA open drivers

### DIFF
--- a/third_party/ansible/roles/cuda/defaults/main.yml
+++ b/third_party/ansible/roles/cuda/defaults/main.yml
@@ -3,6 +3,7 @@
 # By default gpu is False, set it to True on the gpu nodes in the hosts file
 
 gpu: false
+use_open_drivers: false
 cuda_repo_url: http://developer.download.nvidia.com/compute/cuda/repos
 cuda_rpm_key_path: /etc/rpm/nvidia_packaging_key.asc
 cuda_packages:

--- a/third_party/ansible/roles/cuda/tasks/install_runfile.yml
+++ b/third_party/ansible/roles/cuda/tasks/install_runfile.yml
@@ -115,7 +115,7 @@
   when: not (cuda_runtime_file.stat.exists and cuda_runfile_valid_checksum) and ((cuda_runfile_toolkit and not cuda_toolkit_installed) or (cuda_runfile_driver and not cuda_driver_installed))
 
 - name: Run installer for toolkit
-  command: bash /tmp/cuda_runfile/{{ cuda_runfile_sh }} --silent --toolkit
+  command: bash /tmp/cuda_runfile/{{ cuda_runfile_sh }} --silent --toolkit{% if use_open_drivers | bool %} -m=kernel-open{% endif %}
   register: cuda_toolkit_install_out
   when: cuda_runfile_toolkit and not cuda_toolkit_installed
 


### PR DESCRIPTION
The NVIDIA open drivers support GPUs from Turing/Ampere onward. This option allows the user to select these drivers when they are desired. This option remains disabled by default on all OSes until we devise a strategy for supporting GPU models released before Turing/Ampere.


I built a Debian 11 image by hand and confirmed that the proprietary drivers are still installed:

```shell
tpdownes@deb11-0:~$ sudo modinfo nvidia
filename:       /lib/modules/5.10.0-28-cloud-amd64/kernel/drivers/video/nvidia.ko
alias:          char-major-195-*
version:        545.23.08
supported:      external
license:        NVIDIA
...
```