### PR TITLE
Initial support for building Debian 12 images

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -18,6 +18,11 @@
 
   vars:
     min_ansible_version: 2.7
+    supported_distributions:
+    - CentOS
+    - Rocky
+    - Debian
+    - Ubuntu
     paths:
       install: /usr/local
       src: /usr/local/src
@@ -32,31 +37,36 @@
     install_pmix: true
 
   pre_tasks:
-  - name: Supported OS Check
-    assert:
-      that: >
-        ( ansible_distribution == "CentOS" and
-          ansible_distribution_major_version is version('7', '==')
-        ) or
-        ( ansible_distribution == "Rocky" and
-          ansible_distribution_major_version is version('8', '==')
-        ) or
-        ( ansible_distribution == "Debian" and
-          (ansible_distribution_major_version is version('10', '==') or
-          ansible_distribution_major_version is version('11', '=='))
-        ) or
-        ( ansible_distribution == "Ubuntu" and
-          (ansible_distribution_version is version('20.04', '==') or
-          ansible_distribution_version is version('22.04', '=='))
-        )
-      msg: >
-        OS ansible_distribution version ansible_distribution_major_version is not
-        supported.
-        Please use a supported OS in list:
-          - CentOS 7
-          - Rocky 8
-          - Debian 10, 11
-          - Ubuntu 20.04, 22.04
+  - name: Check Supported Distribution
+    ansible.builtin.assert:
+      that: ansible_distribution in supported_distributions
+      fail_msg: |
+        {{ ansible_distribution }} is not supported. Use one of these distributions:
+          {{ supported_distributions }}
+  - name: Check Support on CentOS
+    when: ansible_distribution == "CentOS"
+    ansible.builtin.assert:
+      that: ansible_distribution_major_version is version('7', '==')
+      fail_msg: |
+        When building Slurm-GCP on CentOS, use release 7
+  - name: Check Support on Rocky Linux
+    when: ansible_distribution == "Rocky"
+    ansible.builtin.assert:
+      that: ansible_distribution_major_version is version('8', '==')
+      fail_msg: |
+        When building Slurm-GCP on Rocky Linux, use release 8
+  - name: Check Support on Debian
+    when: ansible_distribution == "Debian"
+    ansible.builtin.assert:
+      that: ansible_distribution_major_version is version('10', '>=')
+      fail_msg: |
+        When building Slurm-GCP on Debian, use release 10 or above
+  - name: Check Support on Ubuntu
+    when: ansible_distribution == "Ubuntu"
+    ansible.builtin.assert:
+      that: ansible_distribution_version is version('20.04', '==') or ansible_distribution_version is version('22.04', '==')
+      fail_msg: |
+        When building Slurm-GCP on Ubuntu, use release 20.04 or 22.04
   - name: Minimum Ansible Version Check
     assert:
       that: ansible_version.full is version_compare({{min_ansible_version}}, '>=')

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -12,6 +12,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 - hosts: all
   become: yes
@@ -58,7 +72,7 @@
   - name: Check Support on Debian
     when: ansible_distribution == "Debian"
     ansible.builtin.assert:
-      that: ansible_distribution_major_version is version('10', '>=')
+      that: ansible_distribution_major_version is version('10', '>=') and ansible_distribution_major_version is version('12', '<=')
       fail_msg: |
         When building Slurm-GCP on Debian, use release 10 or above
   - name: Check Support on Ubuntu

--- a/ansible/roles/cgroups/vars/debian-12.yml
+++ b/ansible/roles/cgroups/vars/debian-12.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) SchedMD LLC.
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,5 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-python38_installed: false
-extra_pip_args: ''
+cgroup_packages:
+- libcgroup2
+- libcgroup-dev
+- libpam-cgroup
+- libdbus-1-dev
+
+cgroup_grub_cmdline_linux:
+- systemd.unified_cgroup_hierarchy=1
+- cgroup_enable=memory
+- swapaccount=1

--- a/ansible/roles/common/vars/debian-12.yml
+++ b/ansible/roles/common/vars/debian-12.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) SchedMD LLC.
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,5 +13,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-python38_installed: false
-extra_pip_args: ''
+common_packages:
+- autoconf
+- automake
+- bash-completion
+- build-essential
+- clang
+- curl
+- doxygen
+- g++
+- gcc
+- git
+- graphviz
+- htop
+- iputils-ping
+- jq
+- libssl-dev
+- libtool
+- llvm
+- make
+- pciutils
+- pdsh
+- pkg-config
+- python3
+- python3-gdbm
+- software-properties-common
+- tmux
+- unzip
+- valgrind
+- vim
+- wget

--- a/ansible/roles/lustre/vars/debian-12.yml
+++ b/ansible/roles/lustre/vars/debian-12.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) SchedMD LLC.
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,5 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-python38_installed: false
-extra_pip_args: ''
+lustre_repo_url: https://downloads.whamcloud.com/public/lustre/latest-feature-release/ubuntu2004/client
+
+lustre_packages:
+- lustre-client-modules
+- lustre-client-utils
+
+# disable lustre install because it's not compatible right now
+lustre_install: false

--- a/ansible/roles/python/files/debian-12_requirements.txt
+++ b/ansible/roles/python/files/debian-12_requirements.txt
@@ -1,0 +1,8 @@
+addict~=2.0
+google-api-python-client~=2.0
+google-cloud-bigquery~=2.0
+google-cloud-secret-manager~=2.0
+google-cloud-storage~=2.0
+google-cloud-tpu~=1.10.0
+more-executors~=2.0
+prometheus-client~=0.16

--- a/ansible/roles/python/tasks/main.yml
+++ b/ansible/roles/python/tasks/main.yml
@@ -37,7 +37,7 @@
   pip:
     name:
     - pip
-    extra_args: --upgrade
+    extra_args: --upgrade {{ extra_pip_args }}
     executable: pip3
     state: present
 
@@ -56,11 +56,11 @@
 
 - name: Install pyyaml workaround
   shell:
-    cmd: pip3 install "Cython<3.0" pyyaml --no-build-isolation
+    cmd: pip3 install "Cython<3.0" pyyaml --no-build-isolation {{ extra_pip_args }}
 
 - name: Install Pip Packages
   pip:
     requirements: '{{ requirements_file.results[0].dest }}'
-    extra_args: --upgrade --ignore-installed
+    extra_args: --upgrade --ignore-installed {{ extra_pip_args }}
     executable: pip3
     state: present

--- a/ansible/roles/python/vars/debian-12.yml
+++ b/ansible/roles/python/vars/debian-12.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) SchedMD LLC.
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,5 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-python38_installed: false
-extra_pip_args: ''
+python_packages:
+- python3
+- python3-pip
+- python3-setuptools
+- python3-virtualenv
+
+extra_pip_args: --break-system-packages

--- a/ansible/roles/python/vars/debian-12.yml
+++ b/ansible/roles/python/vars/debian-12.yml
@@ -19,4 +19,7 @@ python_packages:
 - python3-setuptools
 - python3-virtualenv
 
+# Debian 12 disallows you from installing pip packages in system-wide (/usr)
+# locations. Until we implement a virtual environment based solution, we must
+# force system-wide installation using the arguments below.
 extra_pip_args: --break-system-packages

--- a/ansible/roles/slurm/vars/debian-12.yml
+++ b/ansible/roles/slurm/vars/debian-12.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) SchedMD LLC.
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,5 +13,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-python38_installed: false
-extra_pip_args: ''
+slurm_packages:
+- bind9utils
+- cifs-utils
+- hwloc
+- libcurl4-gnutls-dev
+- libevent-dev
+- libgtk2.0-dev
+- libhdf5-dev
+- libhttp-parser-dev
+- libhwloc-dev
+- libibumad-dev
+- libjson-c-dev
+- libjwt-dev
+- liblua5.3-dev
+- liblz4-dev
+- libncurses-dev
+- libnuma-dev
+- libpam0g-dev
+- libperl-dev
+- libreadline-dev
+- librrd-dev
+- libssh2-1-dev
+- libssl-dev
+- libyaml-dev
+- lua5.3
+- man2html-base
+- numactl
+- rrdtool

--- a/third_party/ansible/roles/cuda/vars/debian-12.yml
+++ b/third_party/ansible/roles/cuda/vars/debian-12.yml
@@ -1,0 +1,3 @@
+---
+cuda_repo_subfolder: debian12
+use_open_drivers: true

--- a/third_party/ansible/roles/cuda/vars/version/latest.yml
+++ b/third_party/ansible/roles/cuda/vars/version/latest.yml
@@ -1,3 +1,3 @@
 ---
-cuda_runfile_url: https://developer.download.nvidia.com/compute/cuda/12.3.2/local_installers/cuda_12.3.2_545.23.08_linux.run
+cuda_runfile_url: https://developer.download.nvidia.com/compute/cuda/12.4.1/local_installers/cuda_12.4.1_550.54.15_linux.run
 nvidia_runfile_url: ''


### PR DESCRIPTION
This commit adds the ability to build Debian 12 images. We should not yet expand claims of support for Debian 12 until this feature is tested more (which this PR will help facilitate).

Future work:

- simplify the Ansible file search structure to avoid so much file duplication
- confirm cgroups v2 behaves as expected in Debian 12-based Slurm clusters
- general testing of Slurm-GCP feature set

I am not certain the update to the CUDA URL is strictly necessary, but the previous version did not build the proprietary drivers successfully. I am choosing to build the open drivers by default on Debian 12 as that is also necessary for use cases with the NVIDIA H100 GPU products we offer.

https://forums.developer.nvidia.com/t/linux-6-7-3-545-29-06-550-40-07-error-modpost-gpl-incompatible-module-nvidia-ko-uses-gpl-only-symbol-rcu-read-lock/280908/40