### PR TITLE
Fix broken link for TPU docker image

### DIFF
--- a/terraform/slurm_cluster/modules/slurm_nodeset_tpu/main.tf
+++ b/terraform/slurm_cluster/modules/slurm_nodeset_tpu/main.tf
@@ -68,7 +68,7 @@ locals {
     service_account        = var.service_account != null ? var.service_account : local.service_account
     preserve_tpu           = local.can_preempt ? var.preserve_tpu : false
     data_disks             = var.data_disks
-    docker_image           = var.docker_image != "" ? var.docker_image : "us-docker.pkg.dev/schedmd-slurm-public/tpu/slurm-gcp-6-4:${var.tf_version}"
+    docker_image           = var.docker_image != "" ? var.docker_image : "us-docker.pkg.dev/schedmd-slurm-public/tpu/slurm-gcp-6-4:tf-${var.tf_version}"
     subnetwork             = local.snetwork
   }
 


### PR DESCRIPTION
This updates the broken link for TPU docker image in artifact registry. 