### PR TITLE
Resolve failed attempt to NFS mount on controller

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -403,7 +403,7 @@ def mount_fstab(mounts):
 def munge_mount_handler():
     if not cfg.munge_mount:
         log.error("Missing munge_mount in cfg")
-    elif lkp.control_host == lkp.hostname:
+    elif lkp.instance_role == "controller":
         return
 
     mount = cfg.munge_mount


### PR DESCRIPTION
The hostname-based test to detect whether the script is running on the controller fails when "hostname" returns a FQDN instead of a short hostname.