### PR TITLE
Add `replace_trigger` to the `_slurm_instance`

### DIFF
--- a/terraform/slurm_cluster/examples/slurm_login_instance/simple/.terraform.lock.hcl
+++ b/terraform/slurm_cluster/examples/slurm_login_instance/simple/.terraform.lock.hcl
@@ -61,6 +61,26 @@ provider "registry.terraform.io/hashicorp/local" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.2"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
+    "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
+    "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
+    "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",
+    "zh:4c2f1faee67af104f5f9e711c4574ff4d298afaa8a420680b0cb55d7bbc65606",
+    "zh:544b33b757c0b954dbb87db83a5ad921edd61f02f1dc86c6186a5ea86465b546",
+    "zh:696cf785090e1e8cf1587499516b0494f47413b43cb99877ad97f5d0de3dc539",
+    "zh:6e301f34757b5d265ae44467d95306d61bef5e41930be1365f5a8dcf80f59452",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:913a929070c819e59e94bb37a2a253c228f83921136ff4a7aa1a178c7cce5422",
+    "zh:aa9015926cd152425dbf86d1abdbc74bfe0e1ba3d26b3db35051d7b9ca9f72ae",
+    "zh:bb04798b016e1e1d49bcc76d62c53b56c88c63d6f2dfe38821afef17c416a0e1",
+    "zh:c23084e1b23577de22603cff752e59128d83cfecc2e6819edadd8cf7a10af11e",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/random" {
   version     = "3.5.1"
   constraints = "~> 3.0"

--- a/terraform/slurm_cluster/modules/_slurm_instance/README_TF.md
+++ b/terraform/slurm_cluster/modules/_slurm_instance/README_TF.md
@@ -23,6 +23,7 @@ limitations under the License.
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.43, < 5.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 
 ## Providers
 
@@ -30,6 +31,7 @@ limitations under the License.
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 3.43, < 5.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
 
 ## Modules
 
@@ -40,6 +42,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [google_compute_instance_from_template.slurm_instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_from_template) | resource |
+| [null_resource.replace_trigger](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [google_compute_instance_template.base](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_instance_template) | data source |
 | [google_compute_zones.available](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_zones) | data source |
 | [local_file.startup](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
@@ -59,6 +62,7 @@ No modules.
 | <a name="input_num_instances"></a> [num\_instances](#input\_num\_instances) | Number of instances to create. This value is ignored if static\_ips is provided. | `number` | `1` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project ID | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region where the instances should be created. | `string` | `null` | no |
+| <a name="input_replace_trigger"></a> [replace\_trigger](#input\_replace\_trigger) | Trigger value to replace the instances. | `string` | `""` | no |
 | <a name="input_slurm_cluster_name"></a> [slurm\_cluster\_name](#input\_slurm\_cluster\_name) | Cluster name, used for resource naming. | `string` | n/a | yes |
 | <a name="input_slurm_instance_role"></a> [slurm\_instance\_role](#input\_slurm\_instance\_role) | Slurm instance type. Must be one of: controller; login; compute. | `string` | `null` | no |
 | <a name="input_static_ips"></a> [static\_ips](#input\_static\_ips) | List of static IPs for VM instances | `list(string)` | `[]` | no |

--- a/terraform/slurm_cluster/modules/_slurm_instance/main.tf
+++ b/terraform/slurm_cluster/modules/_slurm_instance/main.tf
@@ -60,6 +60,11 @@ data "local_file" "startup" {
 #############
 # INSTANCES #
 #############
+resource "null_resource" "replace_trigger" {
+  triggers = {
+    trigger = var.replace_trigger
+  }
+}
 
 resource "google_compute_instance_from_template" "slurm_instance" {
   count   = local.num_instances
@@ -104,4 +109,8 @@ resource "google_compute_instance_from_template" "slurm_instance" {
       VmDnsSetting        = "GlobalOnly"
     },
   )
+
+  lifecycle {
+    replace_triggered_by = [null_resource.replace_trigger.id]
+  }
 }

--- a/terraform/slurm_cluster/modules/_slurm_instance/variables.tf
+++ b/terraform/slurm_cluster/modules/_slurm_instance/variables.tf
@@ -126,3 +126,10 @@ variable "slurm_cluster_name" {
   description = "Cluster name, used for resource naming."
   type        = string
 }
+
+
+variable "replace_trigger" {
+  description = "Trigger value to replace the instances."
+  type        = string
+  default     = ""
+}

--- a/terraform/slurm_cluster/modules/_slurm_instance/versions.tf
+++ b/terraform/slurm_cluster/modules/_slurm_instance/versions.tf
@@ -27,5 +27,9 @@ terraform {
       source  = "hashicorp/local"
       version = "~> 2.0"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
   }
 }


### PR DESCRIPTION
Usage: https://github.com/GoogleCloudPlatform/hpc-toolkit/pull/2413

NOTE: can't use `var.replace_trigger` directly in the `lifecycle.replace_triggered_by` as only resource attributes are 
accepted. Wrap it into `null_resource`