### PR TITLE
Freeze linux kernel during image building

### DIFF
--- a/ansible/group_vars/arch_aarch64.yml
+++ b/ansible/group_vars/arch_aarch64.yml
@@ -13,4 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+debian_family_kernel_package: linux-image-cloud-arm64
 debian_family_kernel_headers_package: linux-headers-cloud-arm64

--- a/ansible/group_vars/arch_aarch64.yml
+++ b/ansible/group_vars/arch_aarch64.yml
@@ -1,0 +1,16 @@
+---
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+debian_family_kernel_headers_package: linux-headers-cloud-arm64

--- a/ansible/group_vars/arch_x86_64.yml
+++ b/ansible/group_vars/arch_x86_64.yml
@@ -13,4 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+debian_family_kernel_package: linux-image-cloud-amd64
 debian_family_kernel_headers_package: linux-headers-cloud-amd64

--- a/ansible/group_vars/arch_x86_64.yml
+++ b/ansible/group_vars/arch_x86_64.yml
@@ -1,0 +1,16 @@
+---
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+debian_family_kernel_headers_package: linux-headers-cloud-amd64

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -57,6 +57,7 @@
     install_lustre: true
     install_gcsfuse: true
     install_pmix: true
+    allow_kernel_upgrades: true
 
   pre_tasks:
   - name: Minimum Ansible Version Check
@@ -93,7 +94,9 @@
   - name: Check Support on Debian
     when: ansible_distribution == "Debian"
     ansible.builtin.assert:
-      that: ansible_distribution_major_version is version('10', '>=') and ansible_distribution_major_version is version('12', '<=')
+      that:
+      - ansible_distribution_major_version is version('10', '>=')
+      - ansible_distribution_major_version is version('12', '<=')
       fail_msg: |
         When building Slurm-GCP on Debian, use release 10 or above
   - name: Check Support on Ubuntu
@@ -102,6 +105,11 @@
       that: ansible_distribution_version is version('20.04', '==') or ansible_distribution_version is version('22.04', '==')
       fail_msg: |
         When building Slurm-GCP on Ubuntu, use release 20.04 or 22.04
+  - name: Freeze kernel before running playbook
+    when: ansible_os_family == "Debian"
+    ansible.builtin.dpkg_selections:
+      name: "{{ debian_family_kernel_package | default('linux-image-cloud-amd64') }}"
+      selection: hold
 
   roles:
   - motd
@@ -147,3 +155,12 @@
   - role: ldap
     when: ansible_os_family != 'Debian'
   - scripts
+
+  post_tasks:
+  - name: Re-enable kernel upgrades by apt-get upgrade
+    when:
+    - ansible_os_family == "Debian"
+    - allow_kernel_upgrades
+    ansible.builtin.dpkg_selections:
+      name: "{{ debian_family_kernel_package | default('linux-image-cloud-amd64') }}"
+      selection: install

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -37,6 +37,9 @@
 
   vars:
     min_ansible_version: 2.7
+    supported_architectures:
+    - x86_64
+    - aarch64
     supported_distributions:
     - CentOS
     - Rocky
@@ -56,12 +59,25 @@
     install_pmix: true
 
   pre_tasks:
+  - name: Minimum Ansible Version Check
+    assert:
+      that: ansible_version.full is version_compare({{min_ansible_version}}, '>=')
+      msg: Update Ansible to at least {{min_ansible_version}} to use this playbook.
   - name: Check Supported Distribution
     ansible.builtin.assert:
       that: ansible_distribution in supported_distributions
       fail_msg: |
-        {{ ansible_distribution }} is not supported. Use one of these distributions:
+        OS {{ ansible_distribution }} is not supported. Use one of these distributions:
           {{ supported_distributions }}
+  - name: Check Supported Architectures
+    ansible.builtin.assert:
+      that: ansible_architecture in supported_architectures
+      fail_msg: |
+        Architecture {{ ansible_architecture }} is not supported. Use one of these architectures:
+          {{ supported_architectures }}
+  - name: Classify hosts by architecture
+    group_by:
+      key: arch_{{ ansible_architecture }}
   - name: Check Support on CentOS
     when: ansible_distribution == "CentOS"
     ansible.builtin.assert:
@@ -86,10 +102,6 @@
       that: ansible_distribution_version is version('20.04', '==') or ansible_distribution_version is version('22.04', '==')
       fail_msg: |
         When building Slurm-GCP on Ubuntu, use release 20.04 or 22.04
-  - name: Minimum Ansible Version Check
-    assert:
-      that: ansible_version.full is version_compare({{min_ansible_version}}, '>=')
-      msg: Update Ansible to at least {{min_ansible_version}} to use this playbook.
 
   roles:
   - motd

--- a/ansible/roles/common/tasks/os/debian.yml
+++ b/ansible/roles/common/tasks/os/debian.yml
@@ -12,12 +12,35 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 - name: Wait for APT Lock
   shell: while fuser /var/lib/dpkg/lock >/dev/null 2>&1; do sleep 5; done;
 
-- name: Upgrade {{ansible_os_family}} Family System Software
-  apt:
-    name: '*'
-    state: latest
+- name: Force update apt cache
+  ansible.builtin.apt:
     update_cache: yes
+    cache_valid_time: 0
+
+- name: Run apt-get upgrade
+  ansible.builtin.apt:
+    upgrade: yes
+
+# dist-upgrade is necessary because "upgrade" refuses to install new
+# dependencies
+- name: Run apt-get dist-upgrade
+  ansible.builtin.apt:
+    upgrade: dist

--- a/ansible/roles/kernel/tasks/os/debian.yml
+++ b/ansible/roles/kernel/tasks/os/debian.yml
@@ -30,24 +30,12 @@
 - block:
   - name: Reboot
     reboot:
-
   - name: Gather facts after reboot
     setup:
-
   when: reboot
 
-- name: Install {{ansible_os_family}} Family Kernel Packages
+- name: Install current and future kernel headers
   ansible.builtin.apt:
     name:
     - linux-headers-{{ansible_kernel}}
-    state: latest
-    update_cache: yes
-  when: reboot
-
-- name: Install {{ansible_os_family}} Family Kernel Packages
-  ansible.builtin.apt:
-    name:
-    - linux-headers-generic
-    state: latest
-    update_cache: yes
-  when: not reboot
+    - "{{ debian_family_kernel_headers_package | default('linux-headers-cloud-amd64') }}"

--- a/third_party/ansible/roles/cuda/tasks/install_runfile.yml
+++ b/third_party/ansible/roles/cuda/tasks/install_runfile.yml
@@ -20,6 +20,7 @@
     - kernel-devel-{{ cuda_driver_kernel_version }}*
     - '@Development tools'
     - which
+    - dkms
     state: present
     update_cache: true
   when: ansible_pkg_mgr in ["yum", "dnf"]
@@ -29,6 +30,7 @@
     name:
     - linux-headers-{{ ansible_kernel }}
     - build-essential
+    - dkms
     state: present
   when: ansible_pkg_mgr == "apt"
 


### PR DESCRIPTION
By freezing the kernel during Debian/Ubuntu image building, we ensure that:

- avoid the need to reboot during the Ansible play, enabling localhost execution (SSH survives reboot)
- the NVIDIA driver is built against the same kernel that will boot when used in a Slurm cluster
- any future deliberate kernel upgrades trigger DKMS, which will rebuild NVIDIA drivers as well as gVNIC (if installed via DKMS package)

If we set `allow_kernel_upgrades: false`, we see that the `linux-image-cloud-amd64` package is held (the first letter `h` below). This prevents `apt-get upgrade` from upgrading the kernel. A user can upgrade the kernel **deliberately** via `apt-get install linux-image-cloud-amd64` or by `apt-mark unhold linux-image-cloud-amd64` and another `apt-get upgrade` / `apt-get dist-upgrade` cycle. We also see that DKMS works as intended, recompiling the gVNIC and NVIDIA drivers for the new kernel.

```
tpdownes_google_com@slurm0-controller:~$ dpkg -l | grep linux-image
ii  linux-image-6.1.0-18-cloud-amd64      6.1.76-1                       amd64        Linux 6.1 for x86-64 cloud (signed)
hi  linux-image-cloud-amd64               6.1.76-1                       amd64        Linux for x86-64 cloud (meta-package)
tpdownes_google_com@slurm0-controller:~$ dpkg -l | grep linux-headers
ii  linux-headers-6.1.0-18-cloud-amd64    6.1.76-1                       amd64        Header files for Linux 6.1.0-18-cloud-amd64
ii  linux-headers-6.1.0-18-common         6.1.76-1                       all          Common header files for Linux 6.1.0-18
ii  linux-headers-6.1.0-20-amd64          6.1.85-1                       amd64        Header files for Linux 6.1.0-20-amd64
ii  linux-headers-6.1.0-20-cloud-amd64    6.1.85-1                       amd64        Header files for Linux 6.1.0-20-cloud-amd64
ii  linux-headers-6.1.0-20-common         6.1.85-1                       all          Common header files for Linux 6.1.0-20
ii  linux-headers-amd64                   6.1.85-1                       amd64        Header files for Linux amd64 configuration (meta-package)
ii  linux-headers-cloud-amd64             6.1.85-1                       amd64        Header files for Linux cloud-amd64 configuration (meta-package)
tpdownes_google_com@slurm0-controller:~$ sudo apt-get upgrade
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Calculating upgrade... Done
The following packages have been kept back:
  linux-image-cloud-amd64
0 upgraded, 0 newly installed, 0 to remove and 1 not upgraded.
tpdownes_google_com@slurm0-controller:~$ sudo apt-get install linux-image-cloud-amd64
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following additional packages will be installed:
  firmware-linux-free linux-image-6.1.0-20-cloud-amd64
Suggested packages:
  linux-doc-6.1 debian-kernel-handbook grub-pc | grub-efi-amd64 | extlinux
The following NEW packages will be installed:
  firmware-linux-free linux-image-6.1.0-20-cloud-amd64
The following held packages will be changed:
  linux-image-cloud-amd64
The following packages will be upgraded:
  linux-image-cloud-amd64
1 upgraded, 2 newly installed, 0 to remove and 0 not upgraded.
Need to get 25.8 MB of archives.
After this operation, 107 MB of additional disk space will be used.
Do you want to continue? [Y/n]
Get:1 file:/etc/apt/mirrors/debian.list Mirrorlist [30 B]
Get:3 file:/etc/apt/mirrors/debian-security.list Mirrorlist [39 B]
Get:2 https://deb.debian.org/debian bookworm/main amd64 firmware-linux-free all 20200122-1 [24.2 kB]
Get:4 https://deb.debian.org/debian-security bookworm-security/main amd64 linux-image-6.1.0-20-cloud-amd64 amd64 6.1.85-1 [25.7 MB]
Get:5 https://deb.debian.org/debian-security bookworm-security/main amd64 linux-image-cloud-amd64 amd64 6.1.85-1 [1500 B]
Fetched 25.8 MB in 0s (55.8 MB/s)
Reading changelogs... Done
Selecting previously unselected package firmware-linux-free.
(Reading database ... 132510 files and directories currently installed.)
Preparing to unpack .../firmware-linux-free_20200122-1_all.deb ...
Unpacking firmware-linux-free (20200122-1) ...
Selecting previously unselected package linux-image-6.1.0-20-cloud-amd64.
Preparing to unpack .../linux-image-6.1.0-20-cloud-amd64_6.1.85-1_amd64.deb ...
Unpacking linux-image-6.1.0-20-cloud-amd64 (6.1.85-1) ...
Preparing to unpack .../linux-image-cloud-amd64_6.1.85-1_amd64.deb ...
Unpacking linux-image-cloud-amd64 (6.1.85-1) over (6.1.76-1) ...
Setting up firmware-linux-free (20200122-1) ...
Setting up linux-image-6.1.0-20-cloud-amd64 (6.1.85-1) ...
/etc/kernel/postinst.d/dkms:
dkms: running auto installation service for kernel 6.1.0-20-cloud-amd64.
Deprecated feature: REMAKE_INITRD (/var/lib/dkms/gve/1.3.4/source/dkms.conf)
Deprecated feature: REMAKE_INITRD (/var/lib/dkms/gve/1.3.4/source/dkms.conf)
Sign command: /usr/lib/linux-kbuild-6.1/scripts/sign-file
Signing key: /var/lib/dkms/mok.key
Public certificate (MOK): /var/lib/dkms/mok.pub

Building module:
Cleaning build area...
make -j4 KERNELRELEASE=6.1.0-20-cloud-amd64 -C /lib/modules/6.1.0-20-cloud-amd64/build M=/var/lib/dkms/dmabuf-import-helper/1.1/build...
Signing module /var/lib/dkms/dmabuf-import-helper/1.1/build/import-helper.ko
Cleaning build area...

import-helper.ko:
Running module version sanity check.
 - Original module
   - No original module exists within this kernel
 - Installation
   - Installing to /lib/modules/6.1.0-20-cloud-amd64/updates/dkms/
depmod...
Sign command: /usr/lib/linux-kbuild-6.1/scripts/sign-file
Signing key: /var/lib/dkms/mok.key
Public certificate (MOK): /var/lib/dkms/mok.pub
Deprecated feature: REMAKE_INITRD (/var/lib/dkms/gve/1.3.4/source/dkms.conf)

Building module:
Cleaning build area...
make -j4 KERNELRELEASE=6.1.0-20-cloud-amd64 KERNELDIR=/lib/modules/6.1.0-20-cloud-amd64/build...
Signing module /var/lib/dkms/gve/1.3.4/build/gve.ko
Cleaning build area...

gve.ko:
Running module version sanity check.
 - Original module
 - Installation
   - Installing to /lib/modules/6.1.0-20-cloud-amd64/updates/dkms/
depmod...
Sign command: /usr/lib/linux-kbuild-6.1/scripts/sign-file
Signing key: /var/lib/dkms/mok.key
Public certificate (MOK): /var/lib/dkms/mok.pub

Building module:
Cleaning build area...
'make' -j8 NV_EXCLUDE_BUILD_MODULES='nvidia-drm ' KERNEL_UNAME=6.1.0-20-cloud-amd64 modules....................
Signing module /var/lib/dkms/nvidia/550.54.15/build/nvidia.ko
Signing module /var/lib/dkms/nvidia/550.54.15/build/nvidia-uvm.ko
Signing module /var/lib/dkms/nvidia/550.54.15/build/nvidia-modeset.ko
Signing module /var/lib/dkms/nvidia/550.54.15/build/nvidia-peermem.ko
Cleaning build area...

nvidia.ko:
Running module version sanity check.
 - Original module
   - No original module exists within this kernel
 - Installation
   - Installing to /lib/modules/6.1.0-20-cloud-amd64/updates/dkms/

nvidia-uvm.ko:
Running module version sanity check.
 - Original module
   - No original module exists within this kernel
 - Installation
   - Installing to /lib/modules/6.1.0-20-cloud-amd64/updates/dkms/

nvidia-modeset.ko:
Running module version sanity check.
 - Original module
   - No original module exists within this kernel
 - Installation
   - Installing to /lib/modules/6.1.0-20-cloud-amd64/updates/dkms/

nvidia-peermem.ko:
Running module version sanity check.
 - Original module
   - No original module exists within this kernel
 - Installation
   - Installing to /lib/modules/6.1.0-20-cloud-amd64/updates/dkms/
depmod...
dkms: autoinstall for kernel: 6.1.0-20-cloud-amd64.
/etc/kernel/postinst.d/initramfs-tools:
update-initramfs: Generating /boot/initrd.img-6.1.0-20-cloud-amd64
/etc/kernel/postinst.d/zz-update-grub:
Generating grub configuration file ...
Found linux image: /boot/vmlinuz-6.1.0-20-cloud-amd64
Found initrd image: /boot/initrd.img-6.1.0-20-cloud-amd64
Found linux image: /boot/vmlinuz-6.1.0-18-cloud-amd64
Found initrd image: /boot/initrd.img-6.1.0-18-cloud-amd64
Warning: os-prober will not be executed to detect other bootable partitions.
Systems on them will not be added to the GRUB boot configuration.
Check GRUB_DISABLE_OS_PROBER documentation entry.
Adding boot menu entry for UEFI Firmware Settings ...
done
Setting up linux-image-cloud-amd64 (6.1.85-1) ...
Processing triggers for initramfs-tools (0.142) ...
update-initramfs: Generating /boot/initrd.img-6.1.0-20-cloud-amd64
tpdownes_google_com@slurm0-controller:~$ sudo dkms status
Deprecated feature: REMAKE_INITRD (/var/lib/dkms/gve/1.3.4/source/dkms.conf)
Deprecated feature: REMAKE_INITRD (/var/lib/dkms/gve/1.3.4/source/dkms.conf)
dmabuf-import-helper/1.1, 6.1.0-18-cloud-amd64, x86_64: installed
dmabuf-import-helper/1.1, 6.1.0-20-cloud-amd64, x86_64: installed
gve/1.3.4, 6.1.0-18-cloud-amd64, x86_64: installed
gve/1.3.4, 6.1.0-20-cloud-amd64, x86_64: installed
nvidia/550.54.15, 6.1.0-18-cloud-amd64, x86_64: installed
nvidia/550.54.15, 6.1.0-20-cloud-amd64, x86_64: installed
```