### PR TITLE
Simplify apt configuration in Ansible playbook

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -30,6 +30,11 @@
 - hosts: all
   become: yes
 
+  module_defaults:
+    ansible.builtin.apt:
+      update_cache: true
+      cache_valid_time: 3600
+
   vars:
     min_ansible_version: 2.7
     supported_distributions:

--- a/ansible/roles/gcsfuse/tasks/os/debian.yml
+++ b/ansible/roles/gcsfuse/tasks/os/debian.yml
@@ -12,6 +12,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 - name: Add Gcsfuse Repository Key 1
   apt_key:
@@ -19,15 +33,13 @@
     state: present
 
 - name: Add Gcsfuse Repository
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: deb https://packages.cloud.google.com/apt gcsfuse-{{ansible_distribution_release}} main
     filename: gcsfuse
-    update_cache: yes
+    update_cache: true
     state: present
 
 - name: Install Gcsfuse
-  apt:
-    name:
-    - gcsfuse
+  ansible.builtin.apt:
+    name: gcsfuse
     state: present
-    update_cache: yes

--- a/ansible/roles/kernel/tasks/os/debian.yml
+++ b/ansible/roles/kernel/tasks/os/debian.yml
@@ -12,6 +12,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 - block:
   - name: Reboot
     reboot:
@@ -22,7 +37,7 @@
   when: reboot
 
 - name: Install {{ansible_os_family}} Family Kernel Packages
-  apt:
+  ansible.builtin.apt:
     name:
     - linux-headers-{{ansible_kernel}}
     state: latest
@@ -30,7 +45,7 @@
   when: reboot
 
 - name: Install {{ansible_os_family}} Family Kernel Packages
-  apt:
+  ansible.builtin.apt:
     name:
     - linux-headers-generic
     state: latest

--- a/ansible/roles/lustre/tasks/os/debian.yml
+++ b/ansible/roles/lustre/tasks/os/debian.yml
@@ -12,9 +12,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 - name: Install Lustre Repo
   ansible.builtin.apt_repository:
     filename: lustre-client
     repo: deb [trusted=yes] {{ lustre_repo_url }} /
     state: present
+    update_cache: true

--- a/third_party/ansible/roles/cuda/tasks/configure_apt_cuda.yml
+++ b/third_party/ansible/roles/cuda/tasks/configure_apt_cuda.yml
@@ -1,14 +1,13 @@
 ---
 # tasks file for ansible-role-cuda
 - name: Trust packaging key for Nvidia repositories (apt)
-  apt:
+  ansible.builtin.apt:
     deb: '{{ cuda_repo_url }}/{{ cuda_repo_subfolder }}/x86_64/cuda-keyring_1.0-1_all.deb'
 
-- name: Update apt cache and remove dkms
-  apt:
+- name: Remove dkms
+  ansible.builtin.apt:
     name: dkms
     state: absent
-    update_cache: true
 
 - name: Hold dkms
   ansible.builtin.dpkg_selections:

--- a/third_party/ansible/roles/cuda/tasks/configure_apt_nvidia.yml
+++ b/third_party/ansible/roles/cuda/tasks/configure_apt_nvidia.yml
@@ -1,6 +1,6 @@
 ---
 - name: Update apt cache
-  apt:
+  ansible.builtin.apt:
     update_cache: true
 
 - name: get nvidia driver version

--- a/third_party/ansible/roles/cuda/tasks/install_runfile.yml
+++ b/third_party/ansible/roles/cuda/tasks/install_runfile.yml
@@ -25,7 +25,7 @@
   when: ansible_pkg_mgr in ["yum", "dnf"]
 
 - name: Ensure kernel headers are installed (apt)
-  apt:
+  ansible.builtin.apt:
     name:
     - linux-headers-{{ ansible_kernel }}
     - build-essential

--- a/third_party/ansible/roles/cuda/tasks/main.yml
+++ b/third_party/ansible/roles/cuda/tasks/main.yml
@@ -13,7 +13,7 @@
     when: ansible_pkg_mgr == 'apt' and (not cuda_runfile_driver or not cuda_runfile_toolkit)
 
   - name: Install NVIDIA driver
-    apt:
+    ansible.builtin.apt:
       name: '{{ nvidia_packages }}'
       state: present
       update_cache: true


### PR DESCRIPTION
This sequence of commits sets the default behavior of apt-get to update the repository cache only when it is out of date. I did not see a large speed up of overall execution time, but running apt-get update so frequently is only likely to introduced unexpected failures (e.g. a remote apt repository failing to respond).