### PR TITLE
Removes unnecessary parameter from nodeset_switch_lines

### DIFF
--- a/scripts/conf.py
+++ b/scripts/conf.py
@@ -486,7 +486,7 @@ def tpu_nodeset_switch_lines(lkp=lkp):
     return "\n".join(filter(None, lines))
 
 
-def nodeset_switch_lines(nodeset, lkp=lkp):
+def nodeset_switch_lines(lkp=lkp):
     lines = []
 
     for nodeset in lkp.cfg.nodeset.values():


### PR DESCRIPTION
The function `nodeset_switch_lines(nodeset, lkp=lkp)` is used to help write the `cloud_topology.conf` file. However, there was a typo when it was called since only `lkp` was given as an argument. This resulted in `lkp` getting passed as the argument for `nodeset` rather than `lkp`. This caused the `cloud_topology.conf` file to get written incorrectly during reconfiguration. Since the parameter `nodeset` is not being utilized, it is best to just remove it. 

This has been manually tested locally.
