### PR TITLE
feat: Add support RedHat 9

### DIFF
--- a/ansible/docker-playbook.yml
+++ b/ansible/docker-playbook.yml
@@ -12,6 +12,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 - hosts: all
   become: no
@@ -48,7 +62,8 @@
           ansible_distribution_version is version('22.04', '=='))
         ) or
         ( ansible_distribution == "RedHat" and
-          ansible_distribution_major_version is version('8', '==')
+          (ansible_distribution_major_version is version('8', '==') or
+          ansible_distribution_major_version is version('9', '=='))
         )
       msg: >
         OS ansible_distribution version ansible_distribution_major_version is not
@@ -56,9 +71,9 @@
         Please use a supported OS in list:
           - CentOS 7
           - Rocky 8
+          - RedHat 8, 9
           - Debian 10, 11
           - Ubuntu 20.04, 22.04
-          - RedHat 8
   - name: Minimum Ansible Version Check
     assert:
       that: ansible_version.full is version_compare({{min_ansible_version}}, '>=')

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -96,9 +96,9 @@
   - name: Check Support on RedHat Linux
     when: ansible_distribution == "RedHat"
     ansible.builtin.assert:
-      that: ansible_distribution_major_version is version('8', '==')
+      that: ansible_distribution_major_version is version('8', '==') or ansible_distribution_major_version is version('9', '==')
       fail_msg: |
-        When building Slurm-GCP on RedHat Linux, use release 8
+        When building Slurm-GCP on RedHat Linux, use release 8 or 9
   - name: Check Support on Debian
     when: ansible_distribution == "Debian"
     ansible.builtin.assert:

--- a/ansible/roles/cgroups/vars/redhat-8.yml
+++ b/ansible/roles/cgroups/vars/redhat-8.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) SchedMD LLC.
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible/roles/cgroups/vars/redhat-9.yml
+++ b/ansible/roles/cgroups/vars/redhat-9.yml
@@ -1,0 +1,19 @@
+---
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cgroup_packages:
+- dbus-devel
+
+cgroup_grub_cmdline_linux: []

--- a/ansible/roles/common/tasks/os/redhat-8.yml
+++ b/ansible/roles/common/tasks/os/redhat-8.yml
@@ -12,6 +12,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 - name: Upgrade {{ ansible_os_family }}-{{ ansible_distribution_major_version }} Family System Software
   yum:

--- a/ansible/roles/common/tasks/os/redhat-9.yml
+++ b/ansible/roles/common/tasks/os/redhat-9.yml
@@ -1,0 +1,32 @@
+---
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Upgrade {{ ansible_os_family }}-{{ ansible_distribution_major_version }} Family System Software
+  yum:
+    # name: '*'
+    # state: latest
+    update_cache: yes
+
+- name: Enable Rocky 9 PowerTools Repository
+  command: dnf config-manager --set-enabled crb
+  when: ansible_distribution == "Rocky"
+
+- name: Enable RHEL 9 CodeReady Repository
+  command: 'dnf config-manager --set-enabled *appstream* *baseos* *codeready-builder*'
+  when: ansible_distribution == "RedHat"
+
+- name: Install epel-release Repository
+  yum:
+    name: "{{ epel_release_package | default('epel-release') }}"

--- a/ansible/roles/common/vars/redhat-8.yml
+++ b/ansible/roles/common/vars/redhat-8.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) SchedMD LLC.
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible/roles/common/vars/redhat-9.yml
+++ b/ansible/roles/common/vars/redhat-9.yml
@@ -1,0 +1,69 @@
+---
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+epel_release_package: https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+
+common_packages:
+- asciidoc
+- autoconf
+- autofs
+- automake
+- bash-completion
+- binutils
+- bison
+- byacc
+- ctags
+- clang
+- curl
+- diffstat
+- dnf-utils
+- elfutils-libelf-devel
+- epel-release
+- flex
+- gcc
+- gcc-c++
+- gdb
+- git
+- glibc-devel
+- graphviz
+- htop
+- intltool
+- jna
+- jq
+- libtool
+- ltrace
+- make
+- openssl-devel
+- patchutils
+- pciutils
+- pdsh
+- perl-Fedora-VSP
+- perl-Sys-Syslog
+- perl-generators
+- pesign
+- pkgconfig
+- pkgconf-m4
+- pkgconf-pkg-config
+- python3
+- redhat-rpm-config
+- rpm-build
+- rpm-sign
+- source-highlight
+- strace
+- systemtap
+- tmux
+- unzip
+- valgrind
+- vim

--- a/ansible/roles/kernel/tasks/os/redhat-9.yml
+++ b/ansible/roles/kernel/tasks/os/redhat-9.yml
@@ -1,0 +1,33 @@
+---
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+- name: Install {{ansible_os_family}} Family Kernel Packages
+  dnf:
+    name:
+    - kernel
+    - kernel-devel
+    - kernel-headers
+    - kernel-modules
+    - kernel-tools
+    - kernel-tools-libs
+    #- kernel-tools-libs-devel
+    - '{{ ansible_distribution | lower }}-release'
+    state: latest
+    update_cache: yes
+- block:
+  - name: Reboot
+    reboot:
+  - name: Gather facts after reboot
+    setup:
+  when: reboot

--- a/ansible/roles/lustre/vars/redhat-9.yml
+++ b/ansible/roles/lustre/vars/redhat-9.yml
@@ -1,0 +1,18 @@
+---
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+lustre_repo_url: https://downloads.whamcloud.com/public/lustre/latest-release/el{{ansible_distribution_version}}/client
+lustre_packages:
+- lustre-client
+- lustre-client-dkms

--- a/ansible/roles/pmix/vars/redhat-9.yml
+++ b/ansible/roles/pmix/vars/redhat-9.yml
@@ -1,0 +1,18 @@
+---
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+pmix_dependencies:
+- libevent-devel
+- hwloc-devel

--- a/ansible/roles/python/files/redhat-9_requirements.txt
+++ b/ansible/roles/python/files/redhat-9_requirements.txt
@@ -1,0 +1,9 @@
+addict~=2.0
+google-api-python-client~=2.0
+google-cloud-bigquery~=2.0
+google-cloud-secret-manager~=2.0
+google-cloud-storage~=2.0
+google-cloud-tpu~=1.10.0
+more-executors~=2.0
+prometheus-client~=0.16
+pyyaml~=6.0

--- a/ansible/roles/python/vars/redhat-8.yml
+++ b/ansible/roles/python/vars/redhat-8.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) SchedMD LLC.
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible/roles/python/vars/redhat-9.yml
+++ b/ansible/roles/python/vars/redhat-9.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+python_packages:
+- python3
+- python3-pip
+- python3-setuptools
+- python3-virtualenv
+- python39
+python39_installed: true

--- a/ansible/roles/slurm/vars/redhat-8.yml
+++ b/ansible/roles/slurm/vars/redhat-8.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) SchedMD LLC.
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible/roles/slurm/vars/redhat-9.yml
+++ b/ansible/roles/slurm/vars/redhat-9.yml
@@ -1,0 +1,42 @@
+---
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+slurm_packages:
+- cifs-utils
+- gtk2-devel
+- hdf5-devel
+- http-parser-devel
+- hwloc
+- hwloc-devel
+- hwloc-gui
+- json-c-devel
+- libcurl-devel
+- libevent-devel
+- libibmad
+- libibumad
+- libyaml-devel
+- lua
+- lua-devel
+- lua-posix
+- lz4-devel
+- man2html-core
+- ncurses-devel
+- numactl
+- numactl-devel
+- openssl-devel
+- pam-devel
+- perl-ExtUtils-MakeMaker
+- readline-devel
+- rrdtool-devel

--- a/ansible/tf-playbook.yml
+++ b/ansible/tf-playbook.yml
@@ -12,6 +12,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 - hosts: all
   become: no
@@ -38,7 +52,8 @@
           ansible_distribution_major_version is version('8', '==')
         ) or
         ( ansible_distribution == "RedHat" and
-          ansible_distribution_major_version is version('8', '==')
+          (ansible_distribution_major_version is version('8', '==') or
+          ansible_distribution_major_version is version('9', '=='))
         ) or
         ( ansible_distribution == "Debian" and
           (ansible_distribution_major_version is version('10', '==') or
@@ -54,6 +69,7 @@
         Please use a supported OS in list:
           - CentOS 7
           - Rocky 8
+          - RedHat 8, 9
           - Debian 10, 11
           - Ubuntu 20.04, 22.04
   - name: Minimum Ansible Version Check

--- a/third_party/ansible/roles/cuda/vars/redhat-9.yml
+++ b/third_party/ansible/roles/cuda/vars/redhat-9.yml
@@ -1,0 +1,4 @@
+---
+cuda_repo_subfolder: rhel9
+
+# vim:ft=ansible:


### PR DESCRIPTION
This PR adds support for RedHat 9 Slurm Custom Image Build.

NOTE: Use cloud-ops agent for observability as stackdriver-agent is not supported in RHEL 9.
This can be easily passed as a variable to ansible playbook  as `-e monitoring_agent=cloud-ops`