### PR TITLE
Eliminate limit on open files for slurmd service

### DIFF
--- a/ansible/roles/slurm/defaults/main.yml
+++ b/ansible/roles/slurm/defaults/main.yml
@@ -39,6 +39,6 @@ slurmrestd_user:
   group: slurmrestd
   gid: 982
 
-slurmd_override_path: /etc/systemd/system/slurmd.service.d/slurmd_restart.conf
+slurmd_override_path: /etc/systemd/system/slurmd.service.d/overrides.conf
 slurmcmd_timeout: 30
 handle_services: true

--- a/ansible/roles/slurm/tasks/service.yml
+++ b/ansible/roles/slurm/tasks/service.yml
@@ -53,9 +53,9 @@
     path: '{{ slurmd_override_path | dirname }}'
     state: directory
 
-- name: Slurmd should restart upon failure
+- name: Slurmd SystemD overrides
   template:
-    src: systemd/slurmd_restart_override.j2
+    src: systemd/slurmd_overrides.j2
     dest: '{{ slurmd_override_path }}'
     mode: 0o644
   notify: Reload SystemD configuration

--- a/ansible/roles/slurm/templates/systemd/slurmd_overrides.j2
+++ b/ansible/roles/slurm/templates/systemd/slurmd_overrides.j2
@@ -1,3 +1,4 @@
 [Service]
+LimitNOFILE=infinity
 RestartSec=15s
 Restart=on-failure


### PR DESCRIPTION
It has been found to be necessary to [eliminate this limit](https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/bec99bb6033fe6059f2cf1dc9e69cbec954cc605/examples/machine-learning/ml-slurm-a3-1-image.yaml#L107-L111) in our solutions using NVIDIA H100 GPUs.