### PR TITLE
Add support for externally-managed prolog and epilog scripts

### DIFF
--- a/terraform/slurm_cluster/modules/slurm_files/README_TF.md
+++ b/terraform/slurm_cluster/modules/slurm_files/README_TF.md
@@ -58,7 +58,10 @@ No modules.
 | [archive_file.slurm_gcp_devel_zip](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [google_storage_bucket.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/storage_bucket) | data source |
 | [local_file.cgroup_conf_tpl](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
+| [local_file.external_epilog](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
+| [local_file.external_prolog](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
 | [local_file.jobsubmit_lua_tpl](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
+| [local_file.setup_external](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
 | [local_file.slurm_conf_tpl](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
 | [local_file.slurmdbd_conf_tpl](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
 
@@ -79,6 +82,7 @@ No modules.
 | <a name="input_enable_bigquery_load"></a> [enable\_bigquery\_load](#input\_enable\_bigquery\_load) | Enables loading of cluster job usage into big query.<br><br>NOTE: Requires Google Bigquery API. | `bool` | `false` | no |
 | <a name="input_enable_debug_logging"></a> [enable\_debug\_logging](#input\_enable\_debug\_logging) | Enables debug logging mode. Not for production use. | `bool` | `false` | no |
 | <a name="input_enable_devel"></a> [enable\_devel](#input\_enable\_devel) | Enables development mode. Not for production use. | `bool` | `false` | no |
+| <a name="input_enable_external_prolog_epilog"></a> [enable\_external\_prolog\_epilog](#input\_enable\_external\_prolog\_epilog) | Automatically enable a script that will execute prolog and epilog scripts<br>shared by NFS from the controller to compute nodes. Find more details at:<br>https://github.com/GoogleCloudPlatform/slurm-gcp/blob/v5/tools/prologs-epilogs/README.md | `bool` | `false` | no |
 | <a name="input_enable_hybrid"></a> [enable\_hybrid](#input\_enable\_hybrid) | Enables use of hybrid controller mode. When true, controller\_hybrid\_config will<br>be used instead of controller\_instance\_config and will disable login instances. | `bool` | `false` | no |
 | <a name="input_enable_slurm_gcp_plugins"></a> [enable\_slurm\_gcp\_plugins](#input\_enable\_slurm\_gcp\_plugins) | Enables calling hooks in scripts/slurm\_gcp\_plugins during cluster resume and suspend. | `any` | `false` | no |
 | <a name="input_epilog_scripts"></a> [epilog\_scripts](#input\_epilog\_scripts) | List of scripts to be used for Epilog. Programs for the slurmd to execute<br>on every node when a user's job completes.<br>See https://slurm.schedmd.com/slurm.conf.html#OPT_Epilog. | <pre>list(object({<br>    filename = string<br>    content  = string<br>  }))</pre> | `[]` | no |

--- a/terraform/slurm_cluster/modules/slurm_files/files/external_epilog.sh
+++ b/terraform/slurm_cluster/modules/slurm_files/files/external_epilog.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [[ -x /opt/apps/adm/slurm/slurm_epilog ]]; then
+	exec /opt/apps/adm/slurm/slurm_epilog
+fi

--- a/terraform/slurm_cluster/modules/slurm_files/files/external_prolog.sh
+++ b/terraform/slurm_cluster/modules/slurm_files/files/external_prolog.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [[ -x /opt/apps/adm/slurm/slurm_prolog ]]; then
+	exec /opt/apps/adm/slurm/slurm_prolog
+fi

--- a/terraform/slurm_cluster/modules/slurm_files/files/setup_external.sh
+++ b/terraform/slurm_cluster/modules/slurm_files/files/setup_external.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e -o pipefail
+
+SLURM_EXTERNAL_ROOT="/opt/apps/adm/slurm"
+SLURM_MUX_FILE="slurm_mux"
+
+mkdir -p "${SLURM_EXTERNAL_ROOT}"
+mkdir -p "${SLURM_EXTERNAL_ROOT}/logs"
+mkdir -p "${SLURM_EXTERNAL_ROOT}/etc"
+
+# create common prolog / epilog "multiplex" script
+if [ ! -f "${SLURM_EXTERNAL_ROOT}/${SLURM_MUX_FILE}" ]; then
+	# indentation matters in EOT below; do not blindly edit!
+	cat <<'EOT' >"${SLURM_EXTERNAL_ROOT}/${SLURM_MUX_FILE}"
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CMD="${0##*/}"
+# Locate script
+BASE=$(readlink -f $0)
+BASE=${BASE%/*}
+
+export CLUSTER_ADM_BASE=${BASE}
+
+# Source config file if it exists for extra DEBUG settings
+# used below
+SLURM_MUX_CONF=${CLUSTER_ADM_BASE}/etc/slurm_mux.conf
+if [[ -r ${SLURM_MUX_CONF} ]]; then
+	source ${SLURM_MUX_CONF}
+fi
+
+# Setup logging if configured and directory exists
+LOGFILE="/dev/null"
+if [[ -d ${DEBUG_SLURM_MUX_LOG_DIR} && ${DEBUG_SLURM_MUX_ENABLE_LOG} == "yes" ]]; then
+	LOGFILE="${DEBUG_SLURM_MUX_LOG_DIR}/${CMD}-${SLURM_SCRIPT_CONTEXT}-job-${SLURMD_NODENAME}.log"
+	exec >>${LOGFILE} 2>&1
+fi
+
+# Global scriptlets
+for SCRIPTLET in ${BASE}/${SLURM_SCRIPT_CONTEXT}.d/*.${SLURM_SCRIPT_CONTEXT}; do
+	if [[ -x ${SCRIPTLET} ]]; then
+		echo "Running ${SCRIPTLET}"
+		${SCRIPTLET} $@ >>${LOGFILE} 2>&1
+	fi
+done
+
+# Per partition scriptlets
+for SCRIPTLET in ${BASE}/partition-${SLURM_JOB_PARTITION}-${SLURM_SCRIPT_CONTEXT}.d/*.${SLURM_SCRIPT_CONTEXT}; do
+	if [[ -x ${SCRIPTLET} ]]; then
+		echo "Running ${SCRIPTLET}"
+		${SCRIPTLET} $@ >>${LOGFILE} 2>&1
+	fi
+done
+EOT
+fi
+
+# ensure proper permissions on slurm_mux script
+chmod 0755 "${SLURM_EXTERNAL_ROOT}/${SLURM_MUX_FILE}"
+
+# create default slurm_mux configuration file
+if [ ! -f "${SLURM_EXTERNAL_ROOT}/etc/slurm_mux.conf" ]; then
+	cat <<'EOT' >"${SLURM_EXTERNAL_ROOT}/etc/slurm_mux.conf"
+# these settings are intended for temporary debugging purposes only; leaving
+# them enabled will write files for each job to a shared NFS directory without
+# any automated cleanup
+DEBUG_SLURM_MUX_LOG_DIR=/opt/apps/adm/slurm/logs
+DEBUG_SLURM_MUX_ENABLE_LOG=no
+EOT
+fi
+
+# create epilog symbolic link
+if [ ! -L "${SLURM_EXTERNAL_ROOT}/slurm_epilog" ]; then
+	cd ${SLURM_EXTERNAL_ROOT}
+	# delete existing file if necessary
+	rm -f slurm_epilog
+	ln -s ${SLURM_MUX_FILE} slurm_epilog
+	cd - >/dev/null
+fi
+
+# create prolog symbolic link
+if [ ! -L "${SLURM_EXTERNAL_ROOT}/slurm_prolog" ]; then
+	cd ${SLURM_EXTERNAL_ROOT}
+	# delete existing file if necessary
+	rm -f slurm_prolog
+	ln -s ${SLURM_MUX_FILE} slurm_prolog
+	cd - >/dev/null
+fi

--- a/terraform/slurm_cluster/modules/slurm_files/variables.tf
+++ b/terraform/slurm_cluster/modules/slurm_files/variables.tf
@@ -210,6 +210,17 @@ EOD
   default = []
 }
 
+variable "enable_external_prolog_epilog" {
+  description = <<EOD
+Automatically enable a script that will execute prolog and epilog scripts
+shared by NFS from the controller to compute nodes. Find more details at:
+https://github.com/GoogleCloudPlatform/slurm-gcp/blob/v5/tools/prologs-epilogs/README.md
+EOD
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
 variable "disable_default_mounts" {
   description = <<-EOD
     Disable default global network storage from the controller

--- a/tools/prologs-epilogs/README.md
+++ b/tools/prologs-epilogs/README.md
@@ -1,0 +1,49 @@
+# Prologs and Epilogs
+
+The following scripts function simultaneously as both prolog and epilog scripts
+when used with the [external epilog and prolog][epe] feature of the
+slurm_controller_instance module.
+
+A typical approach is to stage these files to `/opt/apps/adm/slurm/scripts/` on
+the controller and then use symbolic links pointing from the directories that
+are iterated over by the `slurm_mux` external epilog and prolog feature.
+
+## Directory pattern
+
+For example, if the following symbolic links are created:
+
+```
+/opt/apps/adm/slurm/prolog_slurmd.d/start-rxdm.prolog_slurmd -> ../scripts/receive-data-path-manager
+/opt/apps/adm/slurm/epilog_slurmd.d/stop-rxdm.epilog_slurmd -> ../scripts/receive-data-path-manager
+```
+
+Then the Receive Data Path Manager (RxDM) will be started before every user's
+job and stopped upon job exit, whether successful or failed. They can otherwise
+be run on a partition by partition basis, if they are placed in
+partition-specific directories. In the example below, the partition is named
+"a3":
+
+```
+/opt/apps/adm/slurm/partition-a3-prolog_slurmd.d/start-rxdm.prolog_slurmd -> ../scripts/receive-data-path-manager
+/opt/apps/adm/slurm/partition-a3-epilog_slurmd.d/stop-rxdm.epilog_slurmd -> ../scripts/receive-data-path-manager
+```
+
+## Example implementation
+
+The following sequence of commands will install the global prolog and epilog
+shown above. It will download the script from the latest Slurm-GCP release.
+`master` can be replaced with a specific tagged version if preferred.
+
+```shell
+#!/bin/bash
+mkdir -p /opt/apps/adm/slurm/prolog_slurmd.d
+mkdir -p /opt/apps/adm/slurm/epilog_slurmd.d
+curl -s --create-dirs -o /opt/apps/adm/slurm/scripts/receive-data-path-manager \
+    https://raw.githubusercontent.com/GoogleCloudPlatform/slurm-gcp/master/tools/prologs-epilogs/receive-data-path-manager
+chmod 0755 /opt/apps/adm/slurm/scripts/
+chmod 0755 /opt/apps/adm/slurm/scripts/receive-data-path-manager
+ln -s /opt/apps/adm/slurm/scripts/receive-data-path-manager /opt/apps/adm/slurm/prolog_slurmd.d/start-rxdm.prolog_slurmd
+ln -s /opt/apps/adm/slurm/scripts/receive-data-path-manager /opt/apps/adm/slurm/epilog_slurmd.d/stop-rxdm.epilog_slurmd
+```
+
+[epe]: ../../terraform/slurm_cluster/modules/slurm_files/README_TF.md#input_enable_external_prolog_epilog

--- a/tools/prologs-epilogs/receive-data-path-manager
+++ b/tools/prologs-epilogs/receive-data-path-manager
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# do not invoke RxDM on non-A3 machines
+/usr/bin/curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/machine-type | grep -q "/a3-highgpu-8g$"
+IS_A3=$?
+if [[ "${IS_A3}" -ne 0 ]]; then
+	exit 0
+fi
+
+# do not invoke RxDM on 1-node jobs
+if [[ "${SLURM_JOB_NUM_NODES}" -eq 1 ]]; then
+	exit 0
+fi
+
+# path at which RxDM sockets will be created
+UDS_PATH="/run/tcpx-${SLURM_JOB_ID}"
+
+RXDM_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpx/tcpgpudmarxd-dev:v2.0.12
+if [[ ${SLURM_SCRIPT_CONTEXT} == "prolog_slurmd" ]]; then
+	# Install the TCPX NCCL Plugin
+	docker run --rm -v /var/lib:/var/lib \
+		us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpx/nccl-plugin-gpudirecttcpx-dev:v3.1.8 install
+
+	# Start TCPX receive-datapath-manager
+	GPU_NIC_TOPOLOGY=/opt/tcpdirect_benchmark/gpu_rxq_configuration.textproto
+	GPU_NIC_TOPOLOGY_DIR=$(dirname ${GPU_NIC_TOPOLOGY})
+	if [ ! -f "${GPU_NIC_TOPOLOGY}" ]; then
+		echo "GPU_NIC_TOPOLOGY file ${GPU_NIC_TOPOLOGY} must exist!"
+		exit 1
+	fi
+
+	docker run \
+		--pull=always \
+		--detach \
+		--rm \
+		--name receive-datapath-manager-"${SLURM_JOB_ID}" \
+		--cap-add=NET_ADMIN \
+		--network=host \
+		--privileged \
+		--gpus all \
+		--volume /var/lib/nvidia/lib64:/usr/local/nvidia/lib64 \
+		--volume "${GPU_NIC_TOPOLOGY_DIR}":"${GPU_NIC_TOPOLOGY_DIR}" \
+		--volume "${UDS_PATH}":"${UDS_PATH}" \
+		--env LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/run/tcpx:/usr/lib/lib32:/usr/lib/x86_64-linux-gnu/ \
+		--entrypoint /tcpgpudmarxd/build/app/tcpgpudmarxd \
+		--ulimit memlock=-1 \
+		${RXDM_IMAGE} \
+		--gpu_nic_preset manual \
+		--gpu_nic_topology ${GPU_NIC_TOPOLOGY} \
+		--gpu_shmem_type fd \
+		--uds_path "${UDS_PATH}"
+
+	# Give some time for tcpgpudmarxd to come up
+	sleep 10s
+
+elif [[ ${SLURM_SCRIPT_CONTEXT} == "epilog_slurmd" ]]; then
+	# Shut down rxdm container
+	docker container list --filter "name=receive-datapath-manager-${SLURM_JOB_ID}" --quiet | xargs --no-run-if-empty docker container stop
+	docker container prune --force
+	rm -rf "${UDS_PATH}"
+fi


### PR DESCRIPTION
Forward-port #50 from v5 to add externally-managed prolog/epilog script support to v6