### PR TITLE
Fix NVIDIA open driver installation

### DIFF
--- a/third_party/ansible/roles/cuda/tasks/install_runfile.yml
+++ b/third_party/ansible/roles/cuda/tasks/install_runfile.yml
@@ -117,7 +117,7 @@
   when: not (cuda_runtime_file.stat.exists and cuda_runfile_valid_checksum) and ((cuda_runfile_toolkit and not cuda_toolkit_installed) or (cuda_runfile_driver and not cuda_driver_installed))
 
 - name: Run installer for toolkit
-  command: bash /tmp/cuda_runfile/{{ cuda_runfile_sh }} --silent --toolkit{% if use_open_drivers | bool %} -m=kernel-open{% endif %}
+  command: bash /tmp/cuda_runfile/{{ cuda_runfile_sh }} --silent --toolkit
   register: cuda_toolkit_install_out
   when: cuda_runfile_toolkit and not cuda_toolkit_installed
 
@@ -138,21 +138,25 @@
     find:
       paths: /tmp/cuda_runfile
       patterns: NVIDIA*.run
-    register: cuda_driver_runfile_find
+    register: nvidia_driver_runfile_find
 
   - name: Set NVIDIA runfile path
     set_fact:
-      cuda_driver_runfile: '{{ cuda_driver_runfile_find.files[0].path }}'
+      nvidia_driver_runfile: '{{ nvidia_driver_runfile_find.files[0].path }}'
 
   - name: Print information about driver
     debug:
-      msg: Building driver {{ cuda_driver_runfile }} for kernel {{ cuda_driver_kernel_version }}
+      msg: Building driver {{ nvidia_driver_runfile }} for kernel {{ cuda_driver_kernel_version }}
 
   - name: Install driver
-    command: >
-      bash {{ cuda_driver_runfile }} --silent
-      --kernel-name={{ cuda_driver_kernel_version }}
-      {{ "--no-drm" if cuda_runfile_disable_nvidia_drm else "" }}
+    command:
+      argv:
+      - bash
+      - "{{ nvidia_driver_runfile }}"
+      - --silent
+      - --kernel-name={{ cuda_driver_kernel_version }}
+      - "{{ '-m=kernel-open' if use_open_drivers else '' }}"
+      - "{{ '--no-drm' if cuda_runfile_disable_nvidia_drm else '' }}"
 
   - name: Install nvidia-persistenced systemd-file
     copy:


### PR DESCRIPTION
- in manual testing, the CUDA runfile passes the "-m=kernel-open" parameter to the NVIDIA driver installation script, but the Ansible solution extracts the NVIDIA driver installation script and executes it separately. This commit moves the open driver argument to the NVIDIA runfile
- resolve a confusing naming cuda_driver_runfile (CUDA is a Toolkit, while the drivers are "NVIDIA")

This change has been manually tested with every combination of `cuda_runfile_disable_nvidia_drm` and `use_open_drivers`.