### PR TITLE
Use `lkp.cfg` instead for getting latest nodeset values for `cloud_gres.conf` 

### DIFF
--- a/scripts/conf.py
+++ b/scripts/conf.py
@@ -402,7 +402,7 @@ def gen_cloud_gres_conf(lkp=lkp):
     """generate cloud_gres.conf"""
 
     gpu_nodes = defaultdict(list)
-    for nodeset in cfg.nodeset.values():
+    for nodeset in lkp.cfg.nodeset.values():
         template_info = lkp.template_info(nodeset.instance_template)
         gpu_count = template_info.gpu_count
         if gpu_count == 0:


### PR DESCRIPTION
During reconfigure, `gen_cloud_gres_conf` function is executed and this creates `cloud_gres.conf`. Updating static nodes from 2 to 4 during manual testing found out that the file is outdated and the newly added 2 nodes are put in `inval` state. 

During previous debugging it was found that the it should use `lkp.cfg` instead of `cfg` for nodeset values. This was found out by comparing body of `nodeset_switch_lines` function. 

Also, for this change, I did manually deployed cluster with 2 static nodes and then redeployed cluster with 4 static nodes. After some time these new nodes are added in the cluster. 