### PR TITLE
Don't attach `instance_role` to the instance name

### DIFF
--- a/terraform/slurm_cluster/modules/slurm_instance_template/main.tf
+++ b/terraform/slurm_cluster/modules/slurm_instance_template/main.tf
@@ -63,11 +63,7 @@ locals {
 
   slurm_instance_role = var.slurm_instance_role != null ? lower(var.slurm_instance_role) : null
 
-  name_prefix = (
-    local.slurm_instance_role != null
-    ? "${var.slurm_cluster_name}-${local.slurm_instance_role}-${var.name_prefix}"
-    : "${var.slurm_cluster_name}-${var.name_prefix}"
-  )
+  name_prefix = "${var.slurm_cluster_name}-${var.name_prefix}"
 
   total_egress_bandwidth_tier = var.bandwidth_tier == "tier_1_enabled" ? "TIER_1" : "DEFAULT"
 


### PR DESCRIPTION
BREAKING CHANGE - Hold for 6.5.0