### PR TITLE
Switch from Sockets to SocketsPerBoard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## \[6.4.5\]
+
+- Add support for externally-managed prolog/epilog scripts
+- Add example receive-data-path-manager prolog/epilog
+- Fix installation of NVIDIA open drivers in image building solution
+- Remove slurmd restart cronjob (implemented using SystemD in abb487f1)
+- write Slurm node configurations with SocketsPerBoard rather than Sockets, to
+  align with recommendation in 23.11 documentation
+
 ## \[6.4.4\]
 
 - Add `replace_trigger` to `_slurm_instance` for fine-grained control over

--- a/scripts/conf.py
+++ b/scripts/conf.py
@@ -139,13 +139,15 @@ def nodeset_lines(nodeset, lkp=lkp):
     template_info = lkp.template_info(nodeset.instance_template)
     machine_conf = lkp.template_machine_conf(nodeset.instance_template)
 
+    # follow https://slurm.schedmd.com/slurm.conf.html#OPT_Boards
+    # by setting Boards, SocketsPerBoard, CoresPerSocket, and ThreadsPerCore
     node_def = dict_to_conf(
         {
             "NodeName": "DEFAULT",
             "State": "UNKNOWN",
             "RealMemory": machine_conf.memory,
             "Boards": machine_conf.boards,
-            "Sockets": machine_conf.sockets,
+            "SocketsPerBoard": machine_conf.sockets_per_board,
             "CoresPerSocket": machine_conf.cores_per_socket,
             "ThreadsPerCore": machine_conf.threads_per_core,
             "CPUs": machine_conf.cpus,

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -1826,6 +1826,7 @@ class Lookup:
         machine_conf = NSDict()
         machine_conf.boards = 1  # No information, assume 1
         machine_conf.sockets = machine_type_sockets(template)
+        machine_conf.sockets_per_board = machine_conf.sockets / machine_conf.boards
         machine_conf.threads_per_core = 1
         _div = 2 if getThreadsPerCore(template) == 1 else 1
         machine_conf.cpus = (


### PR DESCRIPTION
On multi-socket machines we have started observing errors similar to

```
scontrol: error: NodeNames=nodeset-[0-1] CPUs=208 match no Sockets, Sockets*CoresPerSocket or Sockets*CoresPerSocket*ThreadsPerCore. Resetting CPUs.
```

Because `Boards` is hard-coded to be present in our configuration, the most sensible thing is to switch from Sockets to SocketsPerBoard (confirmed by conversation with SchedMD). Quoting the documentation on [Boards](https://slurm.schedmd.com/slurm.conf.html#OPT_Boards)

> Number of Baseboards in nodes with a baseboard controller. Note that when Boards is specified, SocketsPerBoard, CoresPerSocket, and ThreadsPerCore should be specified. The default value is 1.