### PR TITLE
Don't log `resourceInUseByAnotherResource` while delete resource policies

### DIFF
--- a/scripts/util.py
+++ b/scripts/util.py
@@ -880,7 +880,7 @@ def ensure_execute(request):
         break
 
 
-def batch_execute(requests, compute=compute, retry_cb=None):
+def batch_execute(requests, compute=compute, retry_cb=None, log_err=log.error):
     """execute list or dict<req_id, request> as batch requests
     retry if retry_cb returns true
     """
@@ -895,7 +895,7 @@ def batch_execute(requests, compute=compute, retry_cb=None):
     def batch_callback(rid, resp, exc):
         nonlocal rate_limited
         if exc is not None:
-            log.error(f"compute request exception {rid}: {exc}")
+            log_err(f"compute request exception {rid}: {exc}")
             if retry_exception(exc):
                 rate_limited = True
             else:


### PR DESCRIPTION
```sh
$ cat slurmsync.log
2024-05-01 22:19:02,640 INFO: deleted 1 of 1 placement groups (testslurml-centosnodeset-1-0)
2024-05-01 22:26:16,690 INFO: deleted 0 of 1 placement groups ()
```