### PR TITLE
Address failure of compute nodes to join clusters

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -732,7 +732,6 @@ def setup_login(args):
     if lkp.control_addr:
         slurmctld_host = f"{lkp.control_host}({lkp.control_addr})"
     slurmd_options = [
-        f"-N {lkp.hostname}",
         f'--conf-server="{slurmctld_host}:{lkp.control_host_port}"',
         f'--conf="Feature={login_nodeset}"',
         "-Z",
@@ -765,7 +764,6 @@ def setup_compute(args):
     if lkp.control_addr:
         slurmctld_host = f"{lkp.control_host}({lkp.control_addr})"
     slurmd_options = [
-        f"-N {lkp.hostname}",
         f'--conf-server="{slurmctld_host}:{lkp.control_host_port}"',
     ]
     if args.slurmd_feature is not None:


### PR DESCRIPTION
We have observed real-world failures of VMs to join clusters as compute nodes due to changing hostnames during boot. Temporarily the VM identifies its hostname as the FQDN and then reverts (correctly) to the short hostname. In a significant percentage of boots, the command line parameters to slurmd are rendered when the hostname is the FQDN. Removing the explicit parameters allows slurmd restarts to dynamically detect the hostname, which is typically correct within seconds.