### PR TITLE
Add release-candidate of RxDM v2

### DIFF
--- a/tools/prologs-epilogs/README.md
+++ b/tools/prologs-epilogs/README.md
@@ -8,6 +8,15 @@ A typical approach is to stage these files to `/opt/apps/adm/slurm/scripts/` on
 the controller and then use symbolic links pointing from the directories that
 are iterated over by the `slurm_mux` external epilog and prolog feature.
 
+## Included scripts
+
+- [receive-data-path-manager](receive-data-path-manager): implements the Receive
+  Data Path Manager solution for Google Cloud VM type a3-highgpu-8g
+- [sudo-oslogin](sudo-oslogin): ensures that users who are configured with the
+  [OS Admin Login role][os-admin-login] can run sudo during Slurm jobs
+- [sudo-all-jobs-users](sudo-all-jobs-users): ensures that every job can run
+  sudo; _this configuration is recommended only for debugging purposes_.
+
 ## Directory pattern
 
 For example, if the following symbolic links are created:
@@ -47,3 +56,4 @@ ln -s /opt/apps/adm/slurm/scripts/receive-data-path-manager /opt/apps/adm/slurm/
 ```
 
 [epe]: ../../terraform/slurm_cluster/modules/slurm_files/README_TF.md#input_enable_external_prolog_epilog
+[os-admin-login]: https://cloud.google.com/compute/docs/oslogin/set-up-oslogin#configure_users

--- a/tools/prologs-epilogs/README.md
+++ b/tools/prologs-epilogs/README.md
@@ -12,6 +12,11 @@ are iterated over by the `slurm_mux` external epilog and prolog feature.
 
 - [receive-data-path-manager](receive-data-path-manager): implements the Receive
   Data Path Manager solution for Google Cloud VM type a3-highgpu-8g
+- [receive-data-path-manager-mega](receive-data-path-manager-mega): implements
+  the Receive Data Path Manager solution for Google Cloud VM type a3-megagpu-8g
+  - _WARNING_: This solution is in Public Preview and may be modified
+    significantly or renamed as a3-megagpu-8g becomes Generally Available.
+    Please review the [CHANGELOG](../../CHANGELOG.md) for announcements.
 - [sudo-oslogin](sudo-oslogin): ensures that users who are configured with the
   [OS Admin Login role][os-admin-login] can run sudo during Slurm jobs
 - [sudo-all-jobs-users](sudo-all-jobs-users): ensures that every job can run

--- a/tools/prologs-epilogs/receive-data-path-manager-mega
+++ b/tools/prologs-epilogs/receive-data-path-manager-mega
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# invoke RxDMv2 on a3-megagpu-8g only
+/usr/bin/curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/machine-type | grep -q "/a3-megagpu-8g$"
+IS_A3_MEGA=$?
+if [[ "${IS_A3_MEGA}" -ne 0 ]]; then
+	exit 0
+fi
+
+# do not invoke RxDM on 1-node jobs
+if [[ "${SLURM_JOB_NUM_NODES}" -eq 1 ]]; then
+	exit 0
+fi
+
+# ensure that dmabuf-import-helper is loaded
+modprobe import-helper
+
+# Populate /etc/hostname for pyxis/enroot
+hostname | tee /etc/hostname
+
+NCCL_PLUGIN_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.0
+RXDM_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.6-sctp
+RXDM_CONTAINER=receive-datapath-manager-"${SLURM_JOB_ID}"
+if [[ ${SLURM_SCRIPT_CONTEXT} == "prolog_slurmd" ]]; then
+	docker container list --filter "name=receive-datapath-manager-*" --quiet | xargs --no-run-if-empty docker container stop
+
+        export PATH=${PATH}:/usr/local/lib/google-cloud-sdk/bin/
+        gcloud auth configure-docker --quiet us-docker.pkg.dev 2>&1 &>/dev/null
+
+	# Install the nccl, nccl-net lib into /var/lib/tcpxo/lib64/.
+	docker run --rm --gpus all --name nccl-installer --network=host --cap-add=NET_ADMIN \
+		--pull=always \
+		--volume /var/lib:/var/lib \
+		--device /dev/nvidia0:/dev/nvidia0 \
+		--device /dev/nvidia1:/dev/nvidia1 \
+		--device /dev/nvidia2:/dev/nvidia2 \
+		--device /dev/nvidia3:/dev/nvidia3 \
+		--device /dev/nvidia4:/dev/nvidia4 \
+		--device /dev/nvidia5:/dev/nvidia5 \
+		--device /dev/nvidia6:/dev/nvidia6 \
+		--device /dev/nvidia7:/dev/nvidia7 \
+		--device /dev/nvidia-uvm:/dev/nvidia-uvm \
+		--device /dev/nvidiactl:/dev/nvidiactl \
+		--device /dev/dmabuf_import_helper:/dev/dmabuf_import_helper \
+		--env LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/var/lib/fastrak/lib64 \
+		${NCCL_PLUGIN_IMAGE} \
+		install
+
+	# Start FasTrak receive-datapath-manager
+	docker run \
+		--detach \
+		--pull=always \
+		--rm \
+		--name ${RXDM_CONTAINER} \
+		--cap-add=NET_ADMIN \
+		--network=host \
+		--privileged \
+		--gpus all \
+		--volume /var/lib/nvidia/lib64:/usr/local/nvidia/lib64 \
+		--volume /dev/dmabuf_import_helper:/dev/dmabuf_import_helper \
+		--env LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu \
+		${RXDM_IMAGE} \
+		--num_hops=2 --num_nics=8 --uid= --alsologtostderr
+
+	# Wait for RxDM
+	counter=0
+	while true; do
+		rxdm_init_log=$(docker container logs ${RXDM_CONTAINER} 2>&1 | grep "Buffer manager initialization complete") || true
+		if [[ -z $rxdm_init_log ]]; then
+			echo "RxDM hasn't finished init yet."
+			docker logs --tail 10 ${RXDM_CONTAINER} || true
+			sleep 2
+			counter=$((counter + 1))
+			if [[ "$counter" -gt 10 ]]; then
+				echo "FAILED to restart rxdm on $(hostname)"
+				exit 1
+				break
+			fi
+		else
+			echo "RxDM initialization complete"
+			break
+		fi
+	done
+elif [[ ${SLURM_SCRIPT_CONTEXT} == "epilog_slurmd" ]]; then
+	# Shut down rxdm container
+	docker container list --filter "name=receive-datapath-manager-*" --quiet | xargs --no-run-if-empty docker container stop
+	docker container prune --force
+fi

--- a/tools/prologs-epilogs/sudo-all-jobs-users
+++ b/tools/prologs-epilogs/sudo-all-jobs-users
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script will grant _every_ Slurm job the privilege to run sudo for the
+# duration of the job. This configuration is not recommended, however may be
+# useful for debugging or development scenarios. A solution that queries the OS
+# Login API and grants sudo access on a user-by-user basis according to their
+# IAM roles is available in this directory: "sudo-oslogin"
+
+if [[ -z "$SLURM_SCRIPT_CONTEXT" ||
+	-z "$SLURM_JOB_USER" ||
+	-z "$SLURM_JOB_ID" ]]; then
+	echo "This script must be run within a Slurm prolog or epilog environment,"
+	exit 0
+fi
+
+SUDOERDIR="/etc/sudoers.d"
+SUDOERFILE="${SUDOERDIR}/slurm-${SLURM_JOB_USER}-${SLURM_JOB_ID}"
+if [[ "$SLURM_SCRIPT_CONTEXT" == "prolog_slurmd" && -d "$SUDOERDIR" ]]; then
+	# ensure that older Slurm NSS configurations are removed
+	sed -i 's,slurm ,,' /etc/nsswitch.conf
+	echo "$SLURM_JOB_USER ALL=(ALL) NOPASSWD: ALL" >"$SUDOERFILE"
+elif [[ "$SLURM_SCRIPT_CONTEXT" == "epilog_slurmd" && -f "$SUDOERFILE" ]]; then
+	rm -f "$SUDOERFILE"
+fi

--- a/tools/prologs-epilogs/sudo-oslogin
+++ b/tools/prologs-epilogs/sudo-oslogin
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# On Google Cloud VMs that have OS Login enabled, this script will query the
+# OS Login API and add users as sudoers if they have the OS Admin Login role.
+# The sudoers entry is added at job start and removed upon job completion.
+
+if ! type -P jq 1>/dev/null; then
+	echo "Must install jq for this script to function."
+	exit 0
+fi
+
+if [[ -z "$SLURM_SCRIPT_CONTEXT" ||
+	-z "$SLURM_JOB_USER" ||
+	-z "$SLURM_JOB_ID" ]]; then
+	echo "This script must be run within a Slurm prolog or epilog environment."
+	exit 0
+fi
+
+# only run this script if OS Login is enabled
+i_config=$(curl -s -H "Metadata-Flavor: Google" \
+	"http://metadata.google.internal/computeMetadata/v1/instance/attributes/?recursive=true" |
+	jq -r '."enable-oslogin"')
+p_config=$(curl -s -H "Metadata-Flavor: Google" \
+	"http://metadata.google.internal/computeMetadata/v1/project/attributes/?recursive=true" |
+	jq -r '."enable-oslogin"')
+if ! [[ "$i_config" == "TRUE" || "$p_config" == "TRUE" && "$i_config" != "FALSE" ]]; then
+	echo "This script must be run on a VM with OS Login enabled."
+	exit 0
+fi
+
+SUDOERDIR="/var/google-sudoers.d"
+SUDOERFILE="${SUDOERDIR}/slurm-${SLURM_JOB_USER}-${SLURM_JOB_ID}"
+if [[ "$SLURM_SCRIPT_CONTEXT" == "prolog_slurmd" && -d "$SUDOERDIR" ]]; then
+	# ensure that older Slurm NSS configurations are removed
+	sed -i 's,slurm ,,' /etc/nsswitch.conf
+
+	USER_OPENID=$(curl -s -H "Metadata-Flavor: Google" \
+		"http://metadata.google.internal/computeMetadata/v1/oslogin/users?username=${SLURM_JOB_USER}" |
+		jq -r '.loginProfiles | .[] | .name')
+
+	curl -s -H "Metadata-Flavor: Google" \
+		"http://metadata.google.internal/computeMetadata/v1/oslogin/authorize?policy=adminLogin&email=${USER_OPENID}" |
+		jq --exit-status 'select(.success) | length == 1' 1>/dev/null
+	USER_ADMIN=$?
+	if [ "$USER_ADMIN" -eq 0 ]; then
+		echo "$SLURM_JOB_USER ALL=(ALL) NOPASSWD: ALL" >"$SUDOERFILE"
+	fi
+elif [[ "$SLURM_SCRIPT_CONTEXT" == "epilog_slurmd" && -f "$SUDOERFILE" ]]; then
+	rm -f "$SUDOERFILE"
+fi


### PR DESCRIPTION
The Receive Data Path Manager ("RxDM") implements RDMA-like behavior on the A3 VM family. This is a release candidate script for the a3-megagpu-8g family. It makes the assumption that the [Dmabuf Importer Helper](https://github.com/google/dmabuf_importer_helper/) has been successfully installed but may/not yet have been loaded.

Near-term work:

- merge with existing script for single a3-highgpu-8g/a3-megagpu-8g script
- likely remove the explicit `modprobe` command.
- likely remove the explicit creation of /etc/hostname in favor of an enroot configuration change in /etc/enroot/mounts.d/20-config.fstab

To avoid merge conflicts, this PR is based off the branch from #109. Only the HEAD of this branch needs to be reviewed. I will merge after #109 is merged.