### PR TITLE
Improve support for dynamic nodes

### DIFF
--- a/scripts/resume.py
+++ b/scripts/resume.py
@@ -560,7 +560,7 @@ def create_nodeset_placement_groups(node_list: list, job_id=0):
     nodeset = lkp.node_nodeset(model)
     if not nodeset.enable_placement:
         return {None: node_list}
-    if not valid_placement_nodes(job_id, node_list):
+    if not valid_placement_nodes(node_list):
         return {None: node_list}
     region = lkp.node_region(model)
 
@@ -618,22 +618,16 @@ def create_nodeset_placement_groups(node_list: list, job_id=0):
     return groups
 
 
-def valid_placement_nodes(job_id, nodelist):
-    machine_types = {
-        lkp.node_prefix(node): lkp.node_template_info(node).machineType
-        for node in nodelist
-    }
-    fail = False
-    invalid_types = ["e2", "t2d", "n1", "t2a", "m1", "m2", "m3"]
-    for prefix, machine_type in machine_types.items():
-        if machine_type.split("-")[0] in invalid_types:
-            log.warn(f"Unsupported machine type for placement policy: {machine_type}.")
-            fail = True
-    if fail:
-        log.warn(
-            f"Please do not use any the following machine types with placement policy: ({','.join(invalid_types)})"
-        )
-        return False
+def valid_placement_nodes(nodelist):
+    invalid_types = frozenset(["e2", "t2d", "n1", "t2a", "m1", "m2", "m3"])
+    for node in nodelist:
+        mt = lkp.node_template_info(node).machineType
+        if mt.split("-")[0] in invalid_types:
+            log.warn(f"Unsupported machine type for placement policy: {mt}.")
+            log.warn(
+                f"Please do not use any the following machine types with placement policy: ({','.join(invalid_types)})"
+            )
+            return False
     return True
 
 

--- a/scripts/tests/README.md
+++ b/scripts/tests/README.md
@@ -1,0 +1,6 @@
+# Unit tests
+
+```sh
+# cwd is scripts/tests
+$ pytest -W ignore::DeprecationWarning
+```

--- a/scripts/tests/test_util.py
+++ b/scripts/tests/test_util.py
@@ -1,0 +1,59 @@
+import sys
+import util
+import pytest
+
+
+sys.path.append("..")  # TODO: make this more robust
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        (
+            "az-buka-23",
+            {
+                "cluster": "az",
+                "nodeset": "buka",
+                "node": "23",
+                "prefix": "az-buka",
+                "range": None,
+                "suffix": "23",
+            },
+        ),
+        (
+            "az-buka-xyzf",
+            {
+                "cluster": "az",
+                "nodeset": "buka",
+                "node": "xyzf",
+                "prefix": "az-buka",
+                "range": None,
+                "suffix": "xyzf",
+            },
+        ),
+        (
+            "az-buka-[2-3]",
+            {
+                "cluster": "az",
+                "nodeset": "buka",
+                "node": "[2-3]",
+                "prefix": "az-buka",
+                "range": "[2-3]",
+                "suffix": None,
+            },
+        ),
+    ],
+)
+def test_node_desc(name, expected):
+    assert util.lkp._node_desc(name) == expected
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "az-buka",
+    ],
+)
+def test_node_desc_fail(name):
+    with pytest.raises(Exception):
+        util.lkp._node_desc(name)


### PR DESCRIPTION
* Relax node name pattern matching to allow MIG instances;
* Prevent attempts to "power manage" and "slurmsync" dynamic nodes:
  * For dynamic partitions add them to `SuspendExcParts` and unset `PowerDownOnIdle`;
  * Skip dynamic nodes during `slurmsync`.
* Remove unused functions;
* Minor refactoring, reduce usage of `NSDict`.