### PR TITLE
Fix image building on Ubuntu distribution

### DIFF
--- a/ansible/group_vars/arch_x86_64.yml
+++ b/ansible/group_vars/arch_x86_64.yml
@@ -13,6 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-debian_family_kernel_package: linux-image-cloud-amd64
-debian_family_kernel_headers_package: linux-headers-cloud-amd64
 deb_arch: amd64

--- a/ansible/group_vars/os_debian.yml
+++ b/ansible/group_vars/os_debian.yml
@@ -13,4 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-deb_arch: arm64
+kernel_package: linux-image-cloud-{{ deb_arch }}
+kernel_headers_package: linux-headers-cloud-{{ deb_arch }}

--- a/ansible/group_vars/os_ubuntu.yml
+++ b/ansible/group_vars/os_ubuntu.yml
@@ -13,4 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-deb_arch: arm64
+kernel_package: linux-image-gcp
+kernel_headers_package: linux-headers-gcp

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -81,6 +81,9 @@
   - name: Classify hosts by architecture
     group_by:
       key: arch_{{ ansible_architecture }}
+  - name: Classify hosts by Linux distribution
+    group_by:
+      key: os_{{ ansible_distribution | lower }}
   - name: Check Support on CentOS
     when: ansible_distribution == "CentOS"
     ansible.builtin.assert:
@@ -116,7 +119,7 @@
   - name: Freeze kernel before running playbook
     when: ansible_os_family == "Debian"
     ansible.builtin.dpkg_selections:
-      name: "{{ debian_family_kernel_package | default('linux-image-cloud-amd64') }}"
+      name: "{{ kernel_package }}"
       selection: hold
 
   roles:
@@ -173,5 +176,5 @@
     - ansible_os_family == "Debian"
     - allow_kernel_upgrades
     ansible.builtin.dpkg_selections:
-      name: "{{ debian_family_kernel_package | default('linux-image-cloud-amd64') }}"
+      name: "{{ kernel_package }}"
       selection: install

--- a/ansible/roles/kernel/tasks/os/debian.yml
+++ b/ansible/roles/kernel/tasks/os/debian.yml
@@ -37,5 +37,5 @@
 - name: Install current and future kernel headers
   ansible.builtin.apt:
     name:
-    - linux-headers-{{ansible_kernel}}
-    - "{{ debian_family_kernel_headers_package | default('linux-headers-cloud-amd64') }}"
+    - linux-headers-{{ ansible_kernel }}
+    - "{{ kernel_headers_package }}"


### PR DESCRIPTION
Correct the name for the packages containing linux kernel and headers. This solution has been manually tested and shown to work as expected with respect to freezing kernel package during most of the Ansible play.
