### PR TITLE
Fix docker image building for TPU use case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## \[6.5.3\]
+
+- Address Docker image building failures for TPU use cases
+- Refactor network storage from setup script to separate script
+- Relax node name pattern matching to accommodate MIG instances (experimental)
+
 ## \[6.5.2\]
 
 - Address image building failure on CentOS 7 and derivatives

--- a/ansible/docker-playbook.yml
+++ b/ansible/docker-playbook.yml
@@ -51,6 +51,7 @@
     install_ompi: true
     install_lustre: true
     install_gcsfuse: true
+    install_pmix: true
 
   pre_tasks:
   - name: Minimum Ansible Version Check
@@ -128,6 +129,9 @@
       install_server: false
   - libjwt
   - lmod
+  - role: pmix
+    when:
+    - install_pmix
   - role: slurm
     vars:
       handle_services: false

--- a/ansible/docker-playbook.yml
+++ b/ansible/docker-playbook.yml
@@ -32,6 +32,15 @@
 
   vars:
     min_ansible_version: 2.7
+    supported_architectures:
+    - x86_64
+    - aarch64
+    supported_distributions:
+    - CentOS
+    - Rocky
+    - RedHat
+    - Debian
+    - Ubuntu
     paths:
       install: /usr/local
       src: /usr/local/src
@@ -44,40 +53,60 @@
     install_gcsfuse: true
 
   pre_tasks:
-  - name: Supported OS Check
-    assert:
-      that: >
-        ( ansible_distribution == "CentOS" and
-          ansible_distribution_major_version is version('7', '==')
-        ) or
-        ( ansible_distribution == "Rocky" and
-          ansible_distribution_major_version is version('8', '==')
-        ) or
-        ( ansible_distribution == "Debian" and
-          (ansible_distribution_major_version is version('10', '==') or
-          ansible_distribution_major_version is version('11', '=='))
-        ) or
-        ( ansible_distribution == "Ubuntu" and
-          (ansible_distribution_version is version('20.04', '==') or
-          ansible_distribution_version is version('22.04', '=='))
-        ) or
-        ( ansible_distribution == "RedHat" and
-          (ansible_distribution_major_version is version('8', '==') or
-          ansible_distribution_major_version is version('9', '=='))
-        )
-      msg: >
-        OS ansible_distribution version ansible_distribution_major_version is not
-        supported.
-        Please use a supported OS in list:
-          - CentOS 7
-          - Rocky 8
-          - RedHat 8, 9
-          - Debian 10, 11
-          - Ubuntu 20.04, 22.04
   - name: Minimum Ansible Version Check
     assert:
       that: ansible_version.full is version_compare({{min_ansible_version}}, '>=')
       msg: Update Ansible to at least {{min_ansible_version}} to use this playbook.
+  - name: Check Supported Distribution
+    ansible.builtin.assert:
+      that: ansible_distribution in supported_distributions
+      fail_msg: |
+        OS {{ ansible_distribution }} is not supported. Use one of these distributions:
+          {{ supported_distributions }}
+  - name: Check Supported Architectures
+    ansible.builtin.assert:
+      that: ansible_architecture in supported_architectures
+      fail_msg: |
+        Architecture {{ ansible_architecture }} is not supported. Use one of these architectures:
+          {{ supported_architectures }}
+  - name: Classify hosts by architecture
+    group_by:
+      key: arch_{{ ansible_architecture }}
+  - name: Classify hosts by Linux distribution
+    group_by:
+      key: os_{{ ansible_distribution | lower }}
+  - name: Check Support on CentOS
+    when: ansible_distribution == "CentOS"
+    ansible.builtin.assert:
+      that: ansible_distribution_major_version is version('7', '==')
+      fail_msg: |
+        When building Slurm-GCP on CentOS, use release 7
+  - name: Check Support on Rocky Linux
+    when: ansible_distribution == "Rocky"
+    ansible.builtin.assert:
+      that: ansible_distribution_major_version is version('8', '==')
+      fail_msg: |
+        When building Slurm-GCP on Rocky Linux, use release 8
+  - name: Check Support on RedHat Linux
+    when: ansible_distribution == "RedHat"
+    ansible.builtin.assert:
+      that: ansible_distribution_major_version is version('8', '==') or ansible_distribution_major_version is version('9', '==')
+      fail_msg: |
+        When building Slurm-GCP on RedHat Linux, use release 8 or 9
+  - name: Check Support on Debian
+    when: ansible_distribution == "Debian"
+    ansible.builtin.assert:
+      that:
+      - ansible_distribution_major_version is version('10', '>=')
+      - ansible_distribution_major_version is version('12', '<=')
+      fail_msg: |
+        When building Slurm-GCP on Debian, use release 10 or above
+  - name: Check Support on Ubuntu
+    when: ansible_distribution == "Ubuntu"
+    ansible.builtin.assert:
+      that: ansible_distribution_version is version('20.04', '==') or ansible_distribution_version is version('22.04', '==')
+      fail_msg: |
+        When building Slurm-GCP on Ubuntu, use release 20.04 or 22.04
 
   roles:
   - motd

--- a/ansible/docker-playbook.yml
+++ b/ansible/docker-playbook.yml
@@ -116,6 +116,7 @@
   - role: kernel
     vars:
       reboot: false
+      tpu_docker_image: true
   - role: selinux
     vars:
       reboot: false

--- a/ansible/docker-playbook.yml
+++ b/ansible/docker-playbook.yml
@@ -52,6 +52,7 @@
     install_lustre: true
     install_gcsfuse: true
     install_pmix: true
+    install_pyxis: true
 
   pre_tasks:
   - name: Minimum Ansible Version Check
@@ -129,6 +130,9 @@
       install_server: false
   - libjwt
   - lmod
+  - role: pyxis
+    when:
+    - install_pyxis
   - role: pmix
     when:
     - install_pmix

--- a/ansible/roles/kernel/defaults/main.yml
+++ b/ansible/roles/kernel/defaults/main.yml
@@ -14,3 +14,4 @@
 # limitations under the License.
 
 reboot: true
+tpu_docker_image: false

--- a/ansible/roles/kernel/tasks/os/debian.yml
+++ b/ansible/roles/kernel/tasks/os/debian.yml
@@ -34,8 +34,16 @@
     setup:
   when: reboot
 
-- name: Install current and future kernel headers
+- name: Install running kernel headers and metapackage to ensure upgrades
   ansible.builtin.apt:
     name:
     - linux-headers-{{ ansible_kernel }}
     - "{{ kernel_headers_package }}"
+  when: not tpu_docker_image
+
+- name: Install generic kernel headers
+  ansible.builtin.apt:
+    name: linux-headers-generic
+  when:
+  - tpu_docker_image
+  - ansible_distribution == "Ubuntu"


### PR DESCRIPTION
Most of the changes below "backport" recent changes to `ansible/playbook.yml` for VM image building into `ansible/docker-playbook.yml` for container image building. The changes that are not directly copied are related to freezing the kernel packages because, conceptually, the running kernel in Docker is dependent upon the parent OS.

Full list:

- backport changes noted above
- add PMIx and pyxis/enroot to ensure MPI and Spank plugin uniformity throughout clusters
- add an explicit knob for TPU image building that controls what kernel header package is installed on Ubuntu images

This PR will become tagged release 6.5.3