### PR TITLE
Resolve dependency mis-ordering in Docker image building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## \[6.5.4\]
+
+- Fix bug introduced in #134 mis-ordering tasks in Docker image building
+
 ## \[6.5.3\]
 
 - Address Docker image building failures for TPU use cases

--- a/ansible/docker-playbook.yml
+++ b/ansible/docker-playbook.yml
@@ -120,6 +120,9 @@
   - role: selinux
     vars:
       reboot: false
+  - role: pmix
+    when:
+    - install_pmix
   - role: cgroups
     vars:
       change_grub: false
@@ -131,16 +134,13 @@
       install_server: false
   - libjwt
   - lmod
-  - role: pyxis
-    when:
-    - install_pyxis
-  - role: pmix
-    when:
-    - install_pmix
   - role: slurm
     vars:
       handle_services: false
   - slurmcmd
+  - role: pyxis
+    when:
+    - install_pyxis
   - role: ompi
     when: install_ompi
   - role: lustre

--- a/ansible/roles/enroot/tasks/os/debian.yml
+++ b/ansible/roles/enroot/tasks/os/debian.yml
@@ -33,8 +33,10 @@
 
 - name: Install Enroot Packages
   ansible.builtin.apt:
-    deb: '{{ item }}'
+    deb: '{{ enroot_pkg }}'
     state: present
-  with_items:
+  loop:
   - /tmp/{{ enroot_deb }}
   - /tmp/{{ enroot_caps_deb }}
+  loop_control:
+    loop_var: enroot_pkg

--- a/ansible/roles/libjwt/tasks/os/debian.yml
+++ b/ansible/roles/libjwt/tasks/os/debian.yml
@@ -14,7 +14,5 @@
 # limitations under the License.
 
 - name: Install {{ansible_os_family}} Family Dependencies
-  apt:
-    name: '{{item}}'
-  loop:
-  - libjansson-dev
+  ansible.builtin.apt:
+    name: libjansson-dev


### PR DESCRIPTION
#134 accidentally mis-ordered the `pyxis` and `slurm` roles while building Docker images. This causes `pmix` to be ordered after `slurm` because `pyxis` draws Slurm in prematurely. This causes Slurm build to fail. The new locations closely match the playbook for VM image building.

While resolving this, I have fixed two warnings about loop variables [already in use](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_loops.html#defining-inner-and-outer-variable-names-with-loop-var).

This has been manually tested to work:

```
> python3 packer/docker/build.py -p <<PROJECT_ID>>
Building base_image ubuntu:22.04
Build tf image 2.15.0
Build tf image 2.14.1
Build tf image 2.14.0
Build tf image 2.13.1
Build tf image 2.13.0
Build tf image 2.12.1
```