### PR TITLE
Hack to enable usage of shared reservations WITHOUT policies attached

### DIFF
--- a/scripts/resume.py
+++ b/scripts/resume.py
@@ -125,7 +125,7 @@ def instance_properties(partition, model, placement_group, labels=None):
 
     if node_group.reservation_name:
         reservation_name = node_group.reservation_name
-        reservation = lkp.reservation(reservation_name)
+        reservation = {}
         props.reservationAffinity = {
             "consumeReservationType": "SPECIFIC_RESERVATION",
             "key": "compute.googleapis.com/reservation-name",


### PR DESCRIPTION
Can be applied on running controller by editing 1-line in `/slurm/scripts/resume.py` 
The `resume.py` can be invoked with `sudo -u slurm /slurm/scripts/resume.py <hostlist>` , e.g.
`sudo -u slurm /slurm/scripts/resume.py rt5-debug-ghpc-[0-1]`