### PR TITLE
Release Slurm-GCP 6.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## \[6.5.6\]
+
+- Fix bug where dynamic nodes with hostname set to FQDN could not be found by
+  slurmsync script; in current architecture, this impacts login nodes. The
+  resulting Exception was uncaught; Solution truncates all nodenames to short
+  hostname before performing comparisons requiring short hostname
+
+## \[6.5.5\]
+
+- Fix bug where compute nodes with hostname set to FQDN could not find their
+  nodeset-specific startup-script
+
 ## \[6.5.4\]
 
 - Fix bug introduced in #134 mis-ordering tasks in Docker image building

--- a/scripts/slurmsync.py
+++ b/scripts/slurmsync.py
@@ -205,7 +205,8 @@ def find_node_status(nodename):
     if lkp.node_is_tpu(nodename):
         return _find_tpu_node_status(nodename, state)
 
-    inst = lkp.instance(nodename)
+    # split below is workaround for VMs whose hostname is FQDN
+    inst = lkp.instance(nodename.split(".")[0])
     power_flags = frozenset(
         ("POWER_DOWN", "POWERING_UP", "POWERING_DOWN", "POWERED_DOWN")
     ) & (state.flags if state is not None else set())

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -1462,8 +1462,8 @@ class Lookup:
         return compute_service()
 
     @cached_property
-    def hostname_short(self):
-        return socket.gethostname().split(".")[0]
+    def hostname(self):
+        return socket.gethostname()
 
     @cached_property
     def hostname_fqdn(self):
@@ -1485,8 +1485,10 @@ class Lookup:
     def _node_desc(self, node_name):
         """Get parts from node name"""
         if not node_name:
-            node_name = self.hostname_short
-        m = self.node_desc_regex.match(node_name)
+            node_name = self.hostname
+        # workaround below is for VMs whose hostname is FQDN
+        node_name_short = node_name.split(".")[0]
+        m = self.node_desc_regex.match(node_name_short)
         if not m:
             raise Exception(f"node name {node_name} is not valid")
         return m.groupdict()


### PR DESCRIPTION
## 6.5.6

- Fix bug where dynamic nodes with hostname set to FQDN could not be found by slurmsync script; in current architecture, this impacts login nodes. The resulting Exception was uncaught; Solution truncates all nodenames to short hostname before performing comparisons requiring short hostname

Extends work performed in e33c07ef.




### Observed results

 ✅ Test 1: confirm nodeset startup-script is working by activating a service at boot

```
srun -N64 systemctl is-active nvidia-dcgm.service
active
active
...
```

 ✅ Test 2: confirm exception no longer appears in slurmsync logs and the login node appears as idle to `sudo sinfo` (x-login partition is "root only")

```
$ sudo cat /var/log/slurm/slurmsync.log
2024-05-29 15:32:45,153 INFO: Restarting slurmctld to make changes take effect.
$ sudo sinfo
PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
x-login      up   infinite      1   idle a3mega-login-001.c.hpc-toolkit-gsc.internal
a3mega*      up   infinite     64   idle a3mega-a3meganodeset-[0-63]
debug        up   infinite      4  idle~ a3mega-debugnodeset-[0-3]
```