### PR TITLE
Initial commit to add provider info to slurm-gcp

### DIFF
--- a/terraform/slurm_cluster/modules/slurm_files/README_TF.md
+++ b/terraform/slurm_cluster/modules/slurm_files/README_TF.md
@@ -78,6 +78,7 @@ No modules.
 | <a name="input_compute_startup_scripts_timeout"></a> [compute\_startup\_scripts\_timeout](#input\_compute\_startup\_scripts\_timeout) | The timeout (seconds) applied to each script in compute\_startup\_scripts. If<br>any script exceeds this timeout, then the instance setup process is considered<br>failed and handled accordingly.<br><br>NOTE: When set to 0, the timeout is considered infinite and thus disabled. | `number` | `300` | no |
 | <a name="input_controller_startup_scripts"></a> [controller\_startup\_scripts](#input\_controller\_startup\_scripts) | List of scripts to be ran on controller VM startup. | <pre>list(object({<br>    filename = string<br>    content  = string<br>  }))</pre> | `[]` | no |
 | <a name="input_controller_startup_scripts_timeout"></a> [controller\_startup\_scripts\_timeout](#input\_controller\_startup\_scripts\_timeout) | The timeout (seconds) applied to each script in controller\_startup\_scripts. If<br>any script exceeds this timeout, then the instance setup process is considered<br>failed and handled accordingly.<br><br>NOTE: When set to 0, the timeout is considered infinite and thus disabled. | `number` | `300` | no |
+| <a name="input_custom_endpoints"></a> [custom\_endpoints](#input\_custom\_endpoints) | Alternate set of API endpoints | `map(string)` | `null` | no |
 | <a name="input_disable_default_mounts"></a> [disable\_default\_mounts](#input\_disable\_default\_mounts) | Disable default global network storage from the controller<br>* /usr/local/etc/slurm<br>* /etc/munge<br>* /home<br>* /apps<br>If these are disabled, the slurm etc and munge dirs must be added manually,<br>or some other mechanism must be used to synchronize the slurm conf files<br>and the munge key across the cluster. | `bool` | `false` | no |
 | <a name="input_enable_bigquery_load"></a> [enable\_bigquery\_load](#input\_enable\_bigquery\_load) | Enables loading of cluster job usage into big query.<br><br>NOTE: Requires Google Bigquery API. | `bool` | `false` | no |
 | <a name="input_enable_debug_logging"></a> [enable\_debug\_logging](#input\_enable\_debug\_logging) | Enables debug logging mode. Not for production use. | `bool` | `false` | no |
@@ -111,6 +112,7 @@ No modules.
 | <a name="input_slurm_control_host_port"></a> [slurm\_control\_host\_port](#input\_slurm\_control\_host\_port) | The port number that the Slurm controller, slurmctld, listens to for work.<br><br>See https://slurm.schedmd.com/slurm.conf.html#OPT_SlurmctldPort | `string` | `"6818"` | no |
 | <a name="input_slurm_log_dir"></a> [slurm\_log\_dir](#input\_slurm\_log\_dir) | Directory where Slurm logs to. | `string` | `"/var/log/slurm"` | no |
 | <a name="input_slurmdbd_conf_tpl"></a> [slurmdbd\_conf\_tpl](#input\_slurmdbd\_conf\_tpl) | Slurm slurmdbd.conf template file path. | `string` | `null` | no |
+| <a name="input_universe_domain"></a> [universe\_domain](#input\_universe\_domain) | Domain address for alternate API universe | `string` | `null` | no |
 
 ## Outputs
 

--- a/terraform/slurm_cluster/modules/slurm_files/main.tf
+++ b/terraform/slurm_cluster/modules/slurm_files/main.tf
@@ -81,6 +81,10 @@ locals {
     slurm_control_addr      = var.enable_hybrid ? var.slurm_control_addr : null
     slurm_bin_dir           = var.enable_hybrid ? local.slurm_bin_dir : null
     slurm_log_dir           = var.enable_hybrid ? local.slurm_log_dir : null
+
+    # Providers
+    universe_domain  = var.universe_domain
+    custom_endpoints = var.custom_endpoints
   }
 
   config_yaml        = "config.yaml"

--- a/terraform/slurm_cluster/modules/slurm_files/variables.tf
+++ b/terraform/slurm_cluster/modules/slurm_files/variables.tf
@@ -437,3 +437,15 @@ variable "munge_mount" {
     mount_options = ""
   }
 }
+
+variable "universe_domain" {
+  description = "Domain address for alternate API universe"
+  type        = string
+  default     = null
+}
+
+variable "custom_endpoints" {
+  description = "Alternate set of API endpoints"
+  type        = map(string)
+  default     = null
+}


### PR DESCRIPTION
This PR adds two variables to the config.yaml file.  These variable will be populated in a blueprint and used to control the API provider information for use with TPCs and other use cases.  The next PR (on slurm-gcp) will use the new values in the config.yaml to configure the API clients in the slurm-gcp python scripts.