### PR TITLE
Implement `to_hostlist_fast`

### DIFF
--- a/scripts/conf.py
+++ b/scripts/conf.py
@@ -451,7 +451,7 @@ class Switch:
             s for s in self.switches if not s.empty()
         ]  # render only non-empty sub switches
         if non_empty:
-            d["Switches"] = util.to_hostlist([s.name for s in non_empty])
+            d["Switches"] = util.to_hostlist_fast([s.name for s in non_empty])
 
         return dict_to_conf(d)
 
@@ -484,7 +484,7 @@ def tpu_nodeset_switch(nodeset: object, lkp: util.Lookup) -> Switch:
             for nodes in util.chunked(nodenames, n=tpuobj.vmcount):
                 sub_switch = Switch(
                     name=f"{switch.name}-{len(switch.switches)}",
-                    nodes=util.to_hostlist(nodes),
+                    nodes=util.to_hostlist_fast(nodes),
                 )
                 switch.switches.append(sub_switch)
     return switch

--- a/scripts/slurmsync.py
+++ b/scripts/slurmsync.py
@@ -38,7 +38,7 @@ from util import (
     run,
     save_config,
     separate,
-    to_hostlist,
+    to_hostlist_fast,
     with_static,
     Lookup,
     NSDict,
@@ -363,7 +363,7 @@ def delete_placement_groups(placement_groups):
         if failures:
             log.error(f"some placement groups failed to delete: {failures}")
     log.info(
-        f"deleted {len(done)} of {len(placement_groups)} placement groups ({to_hostlist(done.keys())})"
+        f"deleted {len(done)} of {len(placement_groups)} placement groups ({to_hostlist_fast(done.keys())})"
     )
 
 
@@ -443,7 +443,8 @@ def sync_slurm():
     }
     if log.isEnabledFor(logging.DEBUG):
         status_nodelist = {
-            status.name: to_hostlist(nodes) for status, nodes in node_statuses.items()
+            status.name: to_hostlist_fast(nodes)
+            for status, nodes in node_statuses.items()
         }
         log.debug(f"node statuses: \n{yaml.safe_dump(status_nodelist).rstrip()}")
 

--- a/scripts/tests/test_topology.py
+++ b/scripts/tests/test_topology.py
@@ -39,21 +39,6 @@ class TstTPU:  # to prevent client initialization durint "TPU.__init__"
     vmcount: int
 
 
-def make_to_hostlist_mock(tbl: Optional[dict[str, str]] = None, strict: bool = False):
-    if tbl is None:
-        tbl = {}
-
-    def se(names: list[str]) -> str:
-        k = ",".join(sorted(names))
-        if k in tbl:
-            return tbl[k]
-        if strict:
-            raise AssertionError(f"to_hostlist mock: unexpected nodenames: '{k}'")
-        return k
-
-    return se
-
-
 def make_to_hostnames_mock(tbl: Optional[dict[str, list[str]]]):
     def se(k: str) -> list[str]:
         if k not in tbl:
@@ -79,17 +64,6 @@ def test_gen_topology_conf_empty():
 
 @mock.patch("util.TPU")
 @mock.patch(
-    "util.to_hostlist",
-    side_effect=make_to_hostlist_mock(
-        {
-            "bold-0,bold-1,bold-2,bold-3": "bold-[0-3]",
-            "m22-bold-0,m22-bold-1,m22-bold-2": "m22-bold-[0-2]",
-            "m22-bold-4,m22-bold-5,m22-bold-6": "m22-bold-[4-6]",
-            "m22-bold-7,m22-bold-8": "m22-bold-[7-8]",
-        }
-    ),
-)
-@mock.patch(
     "util.to_hostnames",
     side_effect=make_to_hostnames_mock(
         {
@@ -105,7 +79,7 @@ def test_gen_topology_conf_empty():
         }
     ),
 )
-def test_gen_topology_conf(to_hostnames_mock, to_hostlist_mock, tpu_mock):
+def test_gen_topology_conf(to_hostnames_mock, tpu_mock):
     cfg = TstCfg(
         nodeset_tpu={
             "a": TstNodesetTpu("bold", node_count_static=4, node_count_dynamic_max=5),

--- a/scripts/tests/test_util.py
+++ b/scripts/tests/test_util.py
@@ -1,9 +1,9 @@
 import sys
-import util
 import pytest
 
-
-sys.path.append("..")  # TODO: make this more robust
+if ".." not in sys.path:
+    sys.path.append("..")  # TODO: make this more robust
+import util
 
 
 @pytest.mark.parametrize(
@@ -57,3 +57,23 @@ def test_node_desc(name, expected):
 def test_node_desc_fail(name):
     with pytest.raises(Exception):
         util.lkp._node_desc(name)
+
+
+@pytest.mark.parametrize(
+    "names,expected",
+    [
+        ("pedro,pedro-1,pedro-2,pedro-01,pedro-02", "pedro,pedro-[1-2,01-02]"),
+        ("pedro,,pedro-1,,pedro-2", "pedro,pedro-[1-2]"),
+        ("pedro-8,pedro-9,pedro-10,pedro-11", "pedro-[8-9,10-11]"),
+        ("pedro-08,pedro-09,pedro-10,pedro-11", "pedro-[08-11]"),
+        ("pedro-08,pedro-09,pedro-8,pedro-9", "pedro-[8-9,08-09]"),
+        ("pedro-10,pedro-08,pedro-09,pedro-8,pedro-9", "pedro-[8-9,08-10]"),
+        ("pedro-8,pedro-9,juan-10,juan-11", "juan-[10-11],pedro-[8-9]"),
+        ("az,buki,vedi", "az,buki,vedi"),
+        ("a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12", "a[0-9,10-12]"),
+        ("a0,a2,a4,a6,a7,a8,a11,a12", "a[0,2,4,6-8,11-12]"),
+        ("seas7-0,seas7-1", "seas7-[0-1]"),
+    ],
+)
+def test_to_hostlist_fast(names, expected):
+    assert util.to_hostlist_fast(names.split(",")) == expected


### PR DESCRIPTION
Implement `to_hostlist_fast` as a replacement for `to_hostlist`.
Initially to be used for topology generation and in logs reporting.
After/if we get confident with it, remove all other usages of `to_hostlist` (~5 places left).


**Motivation:**
* `to_hostlist` dumps input into a file and invokes `scontrol show hostlist` util, that is expensive and creates runtime dependency;
* Reduce runtime dependency for tests (removed `mock_to_hostlist`);
* Latency improvements, critical for topology effort, were this function would be called `O(nodes)` times.

**IMPORTANT:**
  * Acts as `scontrol show hostlistsorted`, i.e. original order is not preserved;
  * Achieves worse "compression" than `to_hostlist` on average.


```py
(/slurm/scripts)# python3.8

>>> from util import to_hostlist, to_hostlist_fast
>>> import timeit, random
>>> make_smpl = lambda N,K: random.sample([f"cluster-shmaster-{i}" for i in range(N)], k=K)

>>> small_smpl = make_smpl(10, 5)
>>> timeit.Timer('to_hostlist_fast(small_smpl)', globals=globals()).timeit(number=100)
0.0012453191448003054
>>> timeit.Timer('to_hostlist(small_smpl)', globals=globals()).timeit(number=100)
0.479724113130942

>>> lrg_smpl = make_smpl(1000, 400)
>>> timeit.Timer('to_hostlist_fast(lrg_smpl)', globals=globals()).timeit(number=100)
0.06356122181750834
>>> timeit.Timer('to_hostlist(lrg_smpl)', globals=globals()).timeit(number=100)
0.8181608670856804
```

```sh
$ pytest -W ignore::DeprecationWarning test_util.py test_topology.py  -vv
...
==================================== 17 passed in 1.28s ============================

```