### PR TITLE
Expose TreeWidth and TopologyPlugin variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## \[6.5.8\]
+
+- Expose TreeWidth and TopologyPlugin variables
+- Add 'source' argument for path to prolog or epilog scripts
+
 ## \[6.5.7\]
 
 - Persist templates content in the config instead of bucket

--- a/scripts/conf.py
+++ b/scripts/conf.py
@@ -86,6 +86,7 @@ def conflines(cloud_parameters, lkp: util.Lookup) -> str:
     }
     prolog_path = Path(dirs.custom_scripts / "prolog.d")
     epilog_path = Path(dirs.custom_scripts / "epilog.d")
+    default_tree_width = 65533 if any_dynamic else None
     conf_options = {
         **(comma_params if not no_comma_params else {}),
         "Prolog": f"{prolog_path}/*" if lkp.cfg.prolog_scripts else None,
@@ -97,9 +98,9 @@ def conflines(cloud_parameters, lkp: util.Lookup) -> str:
         "ResumeTimeout": cloud_parameters.get("resume_timeout", 300),
         "SuspendRate": cloud_parameters.get("suspend_rate", 0),
         "SuspendTimeout": cloud_parameters.get("suspend_timeout", 300),
-        "TreeWidth": "65533" if any_dynamic else None,
+        "TreeWidth": cloud_parameters.get("tree_width", default_tree_width),
         "JobSubmitPlugins": "lua" if any_tpu else None,
-        "TopologyPlugin": "topology/tree",
+        "TopologyPlugin": cloud_parameters.get("topology_plugin", "topology/tree"),
     }
     return dict_to_conf(conf_options, delim="\n")
 

--- a/terraform/slurm_cluster/modules/slurm_files/README_TF.md
+++ b/terraform/slurm_cluster/modules/slurm_files/README_TF.md
@@ -19,7 +19,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | ~> 2.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.53 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.0 |
@@ -64,7 +64,7 @@ No modules.
 | <a name="input_bucket_dir"></a> [bucket\_dir](#input\_bucket\_dir) | Bucket directory for cluster files to be put into. | `string` | `null` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Name of GCS bucket to use. | `string` | n/a | yes |
 | <a name="input_cgroup_conf_tpl"></a> [cgroup\_conf\_tpl](#input\_cgroup\_conf\_tpl) | Slurm cgroup.conf template file path. | `string` | `null` | no |
-| <a name="input_cloud_parameters"></a> [cloud\_parameters](#input\_cloud\_parameters) | cloud.conf options. | <pre>object({<br>    resume_rate     = number<br>    resume_timeout  = number<br>    suspend_rate    = number<br>    suspend_timeout = number<br>  })</pre> | <pre>{<br>  "resume_rate": 0,<br>  "resume_timeout": 300,<br>  "suspend_rate": 0,<br>  "suspend_timeout": 300<br>}</pre> | no |
+| <a name="input_cloud_parameters"></a> [cloud\_parameters](#input\_cloud\_parameters) | cloud.conf options. Default behavior defined in scripts/conf.py | <pre>object({<br>    no_comma_params = optional(bool)<br>    resume_rate     = optional(number)<br>    resume_timeout  = optional(number)<br>    suspend_rate    = optional(number)<br>    suspend_timeout = optional(number)<br>    topology_plugin = optional(string)<br>    tree_width      = optional(number)<br>  })</pre> | `{}` | no |
 | <a name="input_cloudsql_secret"></a> [cloudsql\_secret](#input\_cloudsql\_secret) | Secret URI to cloudsql secret. | `string` | `null` | no |
 | <a name="input_compute_startup_scripts"></a> [compute\_startup\_scripts](#input\_compute\_startup\_scripts) | List of scripts to be ran on compute VM startup. | <pre>list(object({<br>    filename = string<br>    content  = string<br>  }))</pre> | `[]` | no |
 | <a name="input_compute_startup_scripts_timeout"></a> [compute\_startup\_scripts\_timeout](#input\_compute\_startup\_scripts\_timeout) | The timeout (seconds) applied to each script in compute\_startup\_scripts. If<br>any script exceeds this timeout, then the instance setup process is considered<br>failed and handled accordingly.<br><br>NOTE: When set to 0, the timeout is considered infinite and thus disabled. | `number` | `300` | no |

--- a/terraform/slurm_cluster/modules/slurm_files/variables.tf
+++ b/terraform/slurm_cluster/modules/slurm_files/variables.tf
@@ -326,19 +326,17 @@ variable "partitions" {
 }
 
 variable "cloud_parameters" {
-  description = "cloud.conf options."
+  description = "cloud.conf options. Default behavior defined in scripts/conf.py"
   type = object({
-    resume_rate     = number
-    resume_timeout  = number
-    suspend_rate    = number
-    suspend_timeout = number
+    no_comma_params = optional(bool)
+    resume_rate     = optional(number)
+    resume_timeout  = optional(number)
+    suspend_rate    = optional(number)
+    suspend_timeout = optional(number)
+    topology_plugin = optional(string)
+    tree_width      = optional(number)
   })
-  default = {
-    resume_rate     = 0
-    resume_timeout  = 300
-    suspend_rate    = 0
-    suspend_timeout = 300
-  }
+  default = {}
 }
 
 ##########

--- a/terraform/slurm_cluster/modules/slurm_files/versions.tf
+++ b/terraform/slurm_cluster/modules/slurm_files/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 1.2"
+  required_version = "~> 1.3"
   required_providers {
     archive = {
       source  = "hashicorp/archive"


### PR DESCRIPTION
This PR is a no-op. Using optional allows the caller of this module to not have to define the full block. The HPC Toolkit wrappers were already using TF 1.3 and optional feature, but it does more good at this lower level. 

I chose to not override the system default for TreeWidth in this module because 1. to keep this PR a no-op, 2. If we do want to set a default we can do it in the wrapper which is faster to update in the future.