### PR TITLE
Add support for building open source compliant NVIDIA drivers

### DIFF
--- a/third_party/ansible/roles/cuda/defaults/main.yml
+++ b/third_party/ansible/roles/cuda/defaults/main.yml
@@ -3,6 +3,7 @@
 # By default gpu is False, set it to True on the gpu nodes in the hosts file
 
 gpu: false
+use_open_drivers: false
 cuda_repo_url: http://developer.download.nvidia.com/compute/cuda/repos
 cuda_rpm_key_path: /etc/rpm/nvidia_packaging_key.asc
 cuda_packages:

--- a/third_party/ansible/roles/cuda/tasks/install_runfile.yml
+++ b/third_party/ansible/roles/cuda/tasks/install_runfile.yml
@@ -142,22 +142,25 @@
     find:
       paths: /tmp/cuda_runfile
       patterns: NVIDIA*.run
-    register: cuda_driver_runfile_find
+    register: nvidia_driver_runfile_find
 
   - name: Set NVIDIA runfile path
     set_fact:
-      cuda_driver_runfile: '{{ cuda_driver_runfile_find.files[0].path }}'
+      nvidia_driver_runfile: '{{ nvidia_driver_runfile_find.files[0].path }}'
 
   - name: Print information about driver
     debug:
-      msg: Building driver {{ cuda_driver_runfile }} for kernel {{ cuda_driver_kernel_version
-        }}
+      msg: Building driver {{ nvidia_driver_runfile }} for kernel {{ cuda_driver_kernel_version }}
 
   - name: Install driver
-    command: >
-      bash {{ cuda_driver_runfile }} --silent
-      --kernel-name={{ cuda_driver_kernel_version }}
-      {{ "--no-drm" if cuda_runfile_disable_nvidia_drm else "" }}
+    command:
+      argv:
+      - bash
+      - "{{ nvidia_driver_runfile }}"
+      - --silent
+      - --kernel-name={{ cuda_driver_kernel_version }}
+      - "{{ '-m=kernel-open' if use_open_drivers else '' }}"
+      - "{{ '--no-drm' if cuda_runfile_disable_nvidia_drm else '' }}"
 
   - name: Install nvidia-persistenced systemd-file
     copy:


### PR DESCRIPTION
This PR backports #78 and #105 as a single PR to add support for building NVIDIA open source drivers to our v5 releases. The open source drivers are GPL compliant which enables the use of GPL-strict features in the kernel, particularly [dma-buf](https://docs.kernel.org/driver-api/dma-buf.html) which is needed for the A3 VM family on Google Cloud.

This feature is disabled by default to avoid breaking changes for users who do not affirmatively opt-in.

Building against the 5.11.1 tag yields `modinfo nvidia | grep LICENSE`:

```
license:        NVIDIA
```

while building against the feature branch with `use_open_drivers: true` yields:

```
license:        Dual MIT/GPL
```