### PR TITLE
Simplify logging

### DIFF
--- a/scripts/destroy_nodes.py
+++ b/scripts/destroy_nodes.py
@@ -15,7 +15,6 @@
 
 import argparse
 import logging
-from pathlib import Path
 from time import sleep
 from suspend import (
     batch_execute,
@@ -23,10 +22,9 @@ from suspend import (
     truncate_iter,
     wait_for_operations,
 )
-from util import lkp, compute, config_root_logger, parse_self_link
+from util import lkp, compute, parse_self_link
 
-logger_name = Path(__file__).name
-log = logging.getLogger(logger_name)
+log = logging.getLogger()
 
 
 def delete_instances(compute_list):
@@ -112,20 +110,4 @@ if __name__ == "__main__":
     parser.add_argument(
         "--exclude", help="NodeNames excluded from destruction", type=str, default=None
     )
-    parser.add_argument(
-        "--debug",
-        "-d",
-        dest="debug",
-        action="store_true",
-        help="Enable debugging output",
-    )
-
-    args = parser.parse_args()
-
-    logfile = (Path(__file__).parent / logger_name).with_suffix(".log")
-    if args.debug:
-        config_root_logger(logger_name, level="DEBUG", logfile=logfile)
-    else:
-        config_root_logger(logger_name, level="INFO", logfile=logfile)
-
-    main(args)
+    main(parser.parse_args())

--- a/scripts/destroy_resource_policies.py
+++ b/scripts/destroy_resource_policies.py
@@ -15,12 +15,10 @@
 
 import argparse
 import logging
-from pathlib import Path
 from suspend import batch_execute, truncate_iter, wait_for_operations
-from util import lkp, compute, config_root_logger, parse_self_link
+from util import lkp, compute, parse_self_link
 
-logger_name = Path(__file__).name
-log = logging.getLogger(logger_name)
+log = logging.getLogger()
 
 
 def delete_placement_groups(project, region, resourcePolicy):
@@ -89,20 +87,4 @@ if __name__ == "__main__":
     parser.add_argument(
         "--project_id", help="Google cloud project ID", type=str, default=None
     )
-    parser.add_argument(
-        "--debug",
-        "-d",
-        dest="debug",
-        action="store_true",
-        help="Enable debugging output",
-    )
-
-    args = parser.parse_args()
-
-    logfile = (Path(__file__).parent / logger_name).with_suffix(".log")
-    if args.debug:
-        config_root_logger(logger_name, level="DEBUG", logfile=logfile)
-    else:
-        config_root_logger(logger_name, level="INFO", logfile=logfile)
-
-    main(args)
+    main(parser.parse_args())

--- a/scripts/setup_hybrid.py
+++ b/scripts/setup_hybrid.py
@@ -17,29 +17,22 @@
 
 import argparse
 import logging
-import sys
 from pathlib import Path
 import setup
 import util
-from util import lkp, config_root_logger, handle_exception
 
-
-filename = Path(__file__).name
-logfile = Path(filename).with_suffix(".log")
-log = logging.getLogger(filename)
-setup.log.disabled = False
-util.log.disabled = False
+log = logging.getLogger()
 
 
 def main(args):
     log.info("Generating new cloud.conf for slurm.conf")
-    setup.gen_cloud_conf(lkp)
+    setup.gen_cloud_conf(util.lkp)
 
     log.info("Generating new cloud_gres.conf for gres.conf")
-    setup.gen_cloud_gres_conf(lkp)
+    setup.gen_cloud_gres_conf(util.lkp)
 
     log.info("Generating new cloud_topology.conf for topology.conf")
-    setup.gen_topology_conf(lkp)
+    setup.gen_topology_conf(util.lkp)
 
     log.info("Done.")
 
@@ -48,20 +41,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    parser.add_argument(
-        "--debug",
-        "-d",
-        dest="debug",
-        action="store_true",
-        help="Enable debugging output",
-    )
 
-    args = parser.parse_args()
-
-    if args.debug:
-        config_root_logger(filename, level="DEBUG", logfile=logfile)
-    else:
-        config_root_logger(filename, level="INFO", logfile=logfile)
-    sys.excepthook = handle_exception
+    filename = Path(__file__).name
+    logfile = Path(filename).with_suffix(".log")
+    args = util.init_logs_and_parse(log_path=logfile)
 
     main(args)

--- a/scripts/slurmsync.py
+++ b/scripts/slurmsync.py
@@ -45,7 +45,7 @@ from util import (
     TPU,
     chunked,
 )
-from util import lkp, cfg, compute, CONFIG_FILE
+from util import lkp, compute, CONFIG_FILE
 from suspend import delete_instances
 from resume import start_tpu
 from conf import (
@@ -59,10 +59,7 @@ from conf import (
     install_topology_conf,
 )
 
-filename = Path(__file__).name
-LOGFILE = (Path(cfg.slurm_log_dir if cfg else ".") / filename).with_suffix(".log")
-
-log = logging.getLogger(filename)
+log = logging.getLogger()
 
 TOT_REQ_CNT = 1000
 
@@ -524,52 +521,16 @@ def main():
         log.exception("failed to sync custom scripts")
 
 
-parser = argparse.ArgumentParser(
-    description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
-)
-parser.add_argument(
-    "--debug",
-    "-d",
-    dest="loglevel",
-    action="store_const",
-    const=logging.DEBUG,
-    default=logging.INFO,
-    help="Enable debugging output",
-)
-parser.add_argument(
-    "--trace-api",
-    "-t",
-    action="store_true",
-    help="Enable detailed api request output",
-)
-parser.add_argument(
-    "--force",
-    "-f",
-    action="store_true",
-    help="Force tasks to run, regardless of lock.",
-)
-
 if __name__ == "__main__":
-    args = parser.parse_args()
-    util.chown_slurm(LOGFILE, mode=0o600)
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    args = util.init_logs_and_parse(parser)
 
-    if cfg.enable_debug_logging:
-        args.loglevel = logging.DEBUG
-    if args.trace_api:
-        cfg.extra_logging_flags = list(cfg.extra_logging_flags)
-        cfg.extra_logging_flags.append("trace_api")
-    util.config_root_logger(filename, level=args.loglevel, logfile=LOGFILE)
-
-    sys.excepthook = util.handle_exception
-
-    # only run one instance at a time unless --force
-    if args.force:
-        main()
-    else:
-        pid_file = (Path("/tmp") / Path(__file__).name).with_suffix(".pid")
-        with pid_file.open("w") as fp:
-            try:
-                fcntl.lockf(fp, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                main()
-            except BlockingIOError:
-                sys.exit(0)
+    pid_file = (Path("/tmp") / Path(__file__).name).with_suffix(".pid")
+    with pid_file.open("w") as fp:
+        try:
+            fcntl.lockf(fp, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            main()
+        except BlockingIOError:
+            sys.exit(0)


### PR DESCRIPTION
* Use unified method to add logging-specific arguments to parser and use them;
* Use root logger instead of file-specific ones;
* Remove unused `force` arguments and `spawn` function;
* Remove `FlagLogAdapter`, route `subproc` to common logs, remove `hostlists` flag;
