### PR TITLE
Adding pip update to enable devel

### DIFF
--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -55,6 +55,15 @@ function devel::zip() {
 	echo "INFO: Updated permissions of files in '$SCRIPTS_DIR'."
 }
 
+function devel::pip_update() {
+	local REQUIREMENTS="$SCRIPTS_DIR/requirements.txt"
+	if [[ -f "$REQUIREMENTS" ]]; then
+		bash -c "PIP_BREAK_SYSTEM_PACKAGES=1 pip install -U pip"
+		bash -c "PIP_BREAK_SYSTEM_PACKAGES=1 PIP_IGNORE_INSTALLED=1 pip install -U -r \"$REQUIREMENTS\""
+		echo "INFO: Updated pip packages based on $REQUIREMENTS"
+	fi
+}
+
 function config() {
 	local BUCKET="$($CURL $URL/instance/attributes/slurm_bucket_path)"
 	if [[ -z $BUCKET ]]; then
@@ -111,6 +120,7 @@ SETUP_SCRIPT_FILE=$SCRIPTS_DIR/setup.py
 UTIL_SCRIPT_FILE=$SCRIPTS_DIR/util.py
 
 devel::zip
+devel::pip_update
 config
 
 if [ -f $FLAGFILE ]; then


### PR DESCRIPTION
This PR updates the pip packages in a slurm cluster when `enable_devel: True`.  This allows users to update slurm-gcp and test out new features without needing new images every time.  

As of right now, the requirements.txt is automatically bundled with the `enable_devel` files, and isn't present in images normally.  Granted even if it did exist, this shouldn't change the system as these packages would already be installed.

This is currently being tested using [this PR](https://github.com/GoogleCloudPlatform/hpc-toolkit/pull/2748) in the hpc-toolkit.