### PR TITLE
Fix potential issue with CentOS 7 and universe_domain

### DIFF
--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -55,6 +55,15 @@ function devel::zip() {
 	echo "INFO: Updated permissions of files in '$SCRIPTS_DIR'."
 }
 
+function devel::pip_update() {
+	if [[ -f "$REQUIREMENTS" ]]; then
+		local REQUIREMENTS="$SCRIPTS_DIR/requirements.txt"
+		pip install -U pip --break-system-packages
+		pip install -U -r "$REQUIREMENTS" --break-system-packages
+		echo "Updated pip packages based on $REQUIREMENTS"
+	fi
+}
+
 function config() {
 	local BUCKET="$($CURL $URL/instance/attributes/slurm_bucket_path)"
 	if [[ -z $BUCKET ]]; then
@@ -111,6 +120,7 @@ SETUP_SCRIPT_FILE=$SCRIPTS_DIR/setup.py
 UTIL_SCRIPT_FILE=$SCRIPTS_DIR/util.py
 
 devel::zip
+devel::pip_update
 config
 
 if [ -f $FLAGFILE ]; then

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -55,15 +55,6 @@ function devel::zip() {
 	echo "INFO: Updated permissions of files in '$SCRIPTS_DIR'."
 }
 
-function devel::pip_update() {
-	if [[ -f "$REQUIREMENTS" ]]; then
-		local REQUIREMENTS="$SCRIPTS_DIR/requirements.txt"
-		pip install -U pip --break-system-packages
-		pip install -U -r "$REQUIREMENTS" --break-system-packages
-		echo "Updated pip packages based on $REQUIREMENTS"
-	fi
-}
-
 function config() {
 	local BUCKET="$($CURL $URL/instance/attributes/slurm_bucket_path)"
 	if [[ -z $BUCKET ]]; then
@@ -120,7 +111,6 @@ SETUP_SCRIPT_FILE=$SCRIPTS_DIR/setup.py
 UTIL_SCRIPT_FILE=$SCRIPTS_DIR/util.py
 
 devel::zip
-devel::pip_update
 config
 
 if [ -f $FLAGFILE ]; then

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -207,25 +207,30 @@ def get_credentials() -> Optional[service_account.Credentials]:
 
 def create_client_options(api: ApiEndpoint = None) -> ClientOptions:
     """Create client options for cloud endpoints"""
-    ep = None
     ver = endpoint_version(api)
     ud = universe_domain()
-    if ud == DEFAULT_UNIVERSE_DOMAIN:
-        ud = None
+    co = ClientOptions()
+    if ud and ud != DEFAULT_UNIVERSE_DOMAIN:
+        try:
+            co.universe_domain = ud
+        except Exception:
+            log.error(
+                "Universe domain is not part of ClientOptions with installed version of google-api-core."
+            )
+            exit(1)
     if ver:
-        ep = f"https://{api.value}.{ud}/{ver}/"
+        co.api_endpoint = f"https://{api.value}.{ud}/{ver}/"
     log.debug(
         f"Using universe domain: {ud}. "
         + (
-            f"For API: {api.value} using API endpoint: " f"{ep if ep else 'default'}"
+            f"For API: {api.value} using API endpoint: "
+            f"{co.api_endpoint if co.api_endpoint else 'default'}"
             if api
             else ""
         )
     )
-    return ClientOptions(
-        universe_domain=ud,
-        api_endpoint=ep,
-    )
+
+    return co
 
 
 class LogFormatter(logging.Formatter):

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -209,27 +209,13 @@ def create_client_options(api: ApiEndpoint = None) -> ClientOptions:
     """Create client options for cloud endpoints"""
     ver = endpoint_version(api)
     ud = universe_domain()
-    co = ClientOptions()
+    options = {}
     if ud and ud != DEFAULT_UNIVERSE_DOMAIN:
-        try:
-            co.universe_domain = ud
-        except Exception:
-            log.error(
-                "Universe domain is not part of ClientOptions with installed version of google-api-core."
-            )
-            exit(1)
+        options["universe_domain"] = ud
     if ver:
-        co.api_endpoint = f"https://{api.value}.{ud}/{ver}/"
-    log.debug(
-        f"Using universe domain: {ud}. "
-        + (
-            f"For API: {api.value} using API endpoint: "
-            f"{co.api_endpoint if co.api_endpoint else 'default'}"
-            if api
-            else ""
-        )
-    )
-
+        options["api_endpoint"] = f"https://{api.value}.{ud}/{ver}/"
+    co = ClientOptions(**options)
+    log.debug(f"Using ClientOptions = {co} for API: {api.value}")
     return co
 
 


### PR DESCRIPTION
Modified the `create_client_options` function to only conditionally use the `universe_domain` parameter as it does not exist in older versions of `google-api-core`.  This can still throw errors if a user is on CentOS 7 and specifies a universe, but an error will let them know the cause of failure.

This has been tested using the hpc-toolkit on a test branch.  