### PR TITLE
Update receive-data-path-manager-mega

### DIFF
--- a/tools/prologs-epilogs/receive-data-path-manager
+++ b/tools/prologs-epilogs/receive-data-path-manager
@@ -32,7 +32,7 @@ RXDM_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpx/tcpgpudmarxd-dev:v2.0.1
 if [[ ${SLURM_SCRIPT_CONTEXT} == "prolog_slurmd" ]]; then
 	# Install the TCPX NCCL Plugin
 	docker run --rm -v /var/lib:/var/lib \
-		us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpx/nccl-plugin-gpudirecttcpx-dev:v3.1.8 install
+		us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpx/nccl-plugin-gpudirecttcpx-dev:v3.1.9-2.19.4-12.0 install
 
 	# Start TCPX receive-datapath-manager
 	GPU_NIC_TOPOLOGY=/opt/tcpdirect_benchmark/gpu_rxq_configuration.textproto

--- a/tools/prologs-epilogs/receive-data-path-manager-mega
+++ b/tools/prologs-epilogs/receive-data-path-manager-mega
@@ -30,8 +30,8 @@ fi
 # ensure that dmabuf-import-helper is loaded
 modprobe import-helper
 
-NCCL_PLUGIN_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.2
-RXDM_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.8
+NCCL_PLUGIN_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.4
+RXDM_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.10
 RXDM_CONTAINER=receive-datapath-manager-"${SLURM_JOB_ID}"
 if [[ ${SLURM_SCRIPT_CONTEXT} == "prolog_slurmd" ]]; then
 	docker container list --filter "name=receive-datapath-manager-*" --quiet | xargs --no-run-if-empty docker container stop
@@ -57,6 +57,14 @@ if [[ ${SLURM_SCRIPT_CONTEXT} == "prolog_slurmd" ]]; then
 		--env LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/var/lib/tcpxo/lib64 \
 		${NCCL_PLUGIN_IMAGE} \
 		install
+
+	# Modify NCCL env vars for Debian 12
+	cat >> /var/lib/tcpxo/lib64/nccl-env-profile.sh  <<- EOF
+export NCCL_FASTRAK_CTRL_DEV=enp0s12
+export NCCL_FASTRAK_IFNAME=enp6s0,enp7s0,enp13s0,enp14s0,enp134s0,enp135s0,enp141s0,enp142s0
+export NCCL_SOCKET_IFNAME=enp0s12
+export NCCL_FASTRAK_LLCM_DEVICE_DIRECTORY=/dev/aperture_devices
+EOF
 
 	# Start FasTrak receive-datapath-manager
 	docker run \

--- a/tools/prologs-epilogs/receive-data-path-manager-mega
+++ b/tools/prologs-epilogs/receive-data-path-manager-mega
@@ -58,13 +58,17 @@ if [[ ${SLURM_SCRIPT_CONTEXT} == "prolog_slurmd" ]]; then
 		${NCCL_PLUGIN_IMAGE} \
 		install
 
-	# Modify NCCL env vars for Debian 12
-	cat >> /var/lib/tcpxo/lib64/nccl-env-profile.sh  <<- EOF
+	# Modify NCCL env vars for Debian 12. 
+	# /var/lib/tcpxo/lib64/nccl-env-profile.sh is written by the nccl-installer container
+	# above, and assumes interface names of eth{0..8}.
+	if (grep -q "ID=debian" /etc/os-release && lsb_release -rs | grep -q "12"); then
+		cat >> /var/lib/tcpxo/lib64/nccl-env-profile.sh  <<- EOF
 export NCCL_FASTRAK_CTRL_DEV=enp0s12
 export NCCL_FASTRAK_IFNAME=enp6s0,enp7s0,enp13s0,enp14s0,enp134s0,enp135s0,enp141s0,enp142s0
 export NCCL_SOCKET_IFNAME=enp0s12
 export NCCL_FASTRAK_LLCM_DEVICE_DIRECTORY=/dev/aperture_devices
 EOF
+	fi
 
 	# Start FasTrak receive-datapath-manager
 	docker run \

--- a/tools/prologs-epilogs/receive-data-path-manager-mega
+++ b/tools/prologs-epilogs/receive-data-path-manager-mega
@@ -58,7 +58,7 @@ if [[ ${SLURM_SCRIPT_CONTEXT} == "prolog_slurmd" ]]; then
 		${NCCL_PLUGIN_IMAGE} \
 		install
 
-	# Modify NCCL env vars for Debian 12. 
+	# Modify NCCL env vars for Debian 12.
 	# /var/lib/tcpxo/lib64/nccl-env-profile.sh is written by the nccl-installer container
 	# above, and assumes interface names of eth{0..8}.
 	if (grep -q "ID=debian" /etc/os-release && lsb_release -rs | grep -q "12"); then


### PR DESCRIPTION
Update to latest RxDM and NCCL Plugin. 

Also add a helper that overrides the network interfaces for Debian12 on top of the /var/lib/TCPXO/lib64/nccl-env-profile.sh, so that we can remove those from downstream scripts.