### PR TITLE
Adding variable control of kernel update

### DIFF
--- a/ansible/docker-playbook.yml
+++ b/ansible/docker-playbook.yml
@@ -53,6 +53,7 @@
     install_gcsfuse: true
     install_pmix: true
     install_pyxis: true
+    update_kernel: true
 
   pre_tasks:
   - name: Minimum Ansible Version Check
@@ -117,6 +118,7 @@
     vars:
       reboot: false
       tpu_docker_image: true
+      update_kernel: "{{ update_kernel }}"
   - role: selinux
     vars:
       reboot: false

--- a/ansible/roles/kernel/defaults/main.yml
+++ b/ansible/roles/kernel/defaults/main.yml
@@ -15,3 +15,4 @@
 
 reboot: true
 tpu_docker_image: false
+update_kernel: true

--- a/ansible/roles/kernel/tasks/os/redhat-7.yml
+++ b/ansible/roles/kernel/tasks/os/redhat-7.yml
@@ -22,7 +22,15 @@
 
   when: reboot
 
-- name: Install {{ansible_os_family}} Family Kernel Packages
+- name: Install {{ansible_os_family}} Family Kernel Package
+  dnf:
+    name:
+    - kernel
+    state: latest
+    update_cache: yes
+  when: update_kernel
+
+- name: Install {{ansible_os_family}} Family Kernel Helper Packages
   yum:
     name:
     - kernel

--- a/ansible/roles/kernel/tasks/os/redhat-8.yml
+++ b/ansible/roles/kernel/tasks/os/redhat-8.yml
@@ -12,17 +12,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-- name: Install {{ansible_os_family}} Family Kernel Packages
+- name: Install {{ansible_os_family}} Family Kernel Package
   dnf:
     name:
     - kernel
+    - '{{ ansible_distribution | lower }}-release'
+    state: latest
+    update_cache: yes
+  when: update_kernel
+
+- name: Install {{ansible_os_family}} Family Kernel Helper Packages
+  dnf:
+    name:
     - kernel-devel
     - kernel-headers
     - kernel-modules
     - kernel-tools
     - kernel-tools-libs
     #- kernel-tools-libs-devel
-    - '{{ ansible_distribution | lower }}-release'
     state: latest
     update_cache: yes
 - block:

--- a/ansible/roles/kernel/tasks/os/redhat-9.yml
+++ b/ansible/roles/kernel/tasks/os/redhat-9.yml
@@ -12,17 +12,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-- name: Install {{ansible_os_family}} Family Kernel Packages
+- name: Install {{ansible_os_family}} Family Kernel Package
   dnf:
     name:
     - kernel
+    - '{{ ansible_distribution | lower }}-release'
+    state: latest
+    update_cache: yes
+  when: update_kernel
+
+- name: Install {{ansible_os_family}} Family Kernel Helper Packages
+  dnf:
+    name:
     - kernel-devel
     - kernel-headers
     - kernel-modules
     - kernel-tools
     - kernel-tools-libs
     #- kernel-tools-libs-devel
-    - '{{ ansible_distribution | lower }}-release'
     state: latest
     update_cache: yes
 - block:


### PR DESCRIPTION
It might not always be the best to update the kernel - especially with images that are built with specific kernel tied drivers in mind.  This provides a mechanism to circumvent at least updating the kernel and release version.