### PR TITLE
Remove `VmDnsSetting` override, rely on project default

### DIFF
--- a/scripts/resume.py
+++ b/scripts/resume.py
@@ -75,7 +75,6 @@ def instance_properties(nodeset, model, placement_group, labels=None):
         "startup-script": (
             Path(cfg.slurm_scripts_dir or util.dirs.scripts) / "startup.sh"
         ).read_text(),
-        "VmDnsSetting": "GlobalOnly",
     }
     info_metadata = {
         item.get("key"): item.get("value") for item in template_info.metadata["items"]

--- a/terraform/slurm_cluster/modules/_slurm_instance/main.tf
+++ b/terraform/slurm_cluster/modules/_slurm_instance/main.tf
@@ -145,7 +145,6 @@ resource "google_compute_instance_from_template" "slurm_instance" {
       slurm_cluster_name  = var.slurm_cluster_name
       slurm_instance_role = local.slurm_instance_role
       startup-script      = data.local_file.startup.content
-      VmDnsSetting        = "GlobalOnly"
     },
   )
 

--- a/terraform/slurm_cluster/modules/slurm_instance_template/main.tf
+++ b/terraform/slurm_cluster/modules/slurm_instance_template/main.tf
@@ -141,7 +141,6 @@ module "instance_template" {
       slurm_bucket_path   = var.slurm_bucket_path
       slurm_cluster_name  = var.slurm_cluster_name
       slurm_instance_role = local.slurm_instance_role
-      VmDnsSetting        = "GlobalOnly"
     },
   )
 


### PR DESCRIPTION
Each VM inherits VmDnsSetting from the project, alternatively it can override by using metadata.
`GlobalOnly` is to be deprecated in favor of zonal DNS. See https://cloud.google.com/compute/docs/networking/zonal-dns#migrate-to-zonal