### PR TITLE
Remove extra logging receivers and add addtional labels to cloud ops …

### DIFF
--- a/ansible/roles/cloudagents/templates/ops_agent.yaml.j2
+++ b/ansible/roles/cloudagents/templates/ops_agent.yaml.j2
@@ -14,66 +14,54 @@
 
 logging:
   receivers:
-    slurmdbd:
+    slurm_daemon:
       type: files
       include_paths:
       - /var/log/slurm/slurmdbd.log
-    slurmrestd:
-      type: files
-      include_paths:
-      - /var/log/slurm/slurmrestd.log
-    slurmctld:
-      type: files
-      include_paths:
       - /var/log/slurm/slurmctld.log
-    slurmd:
-      type: files
-      include_paths:
       - /var/log/slurm/slurmd-*.log
-    slurm_resume:
-      type: files
-      include_paths:
-      - /var/log/slurm/resume.log
-    slurm_suspend:
+      - /var/log/slurm/slurmrestd.log
+      record_log_file_path: true
+    slurm:
       type: files
       include_paths:
       - /var/log/slurm/suspend.log
-    slurm_sync:
-      type: files
-      include_paths:
       - /var/log/slurm/slurmsync.log
+      - /var/log/slurm/resume.log
+      record_log_file_path: true
     setup:
       type: files
       include_paths:
       - /slurm/scripts/setup.log
+      record_log_file_path: true
   processors:
     parse_slurmlog:
       type: parse_regex
       field: message
-      regex: "^\[(?<time>\S+)\] (?<message>((?<severity>(fatal|error|verbose|debug[0-9]?)):)?.*)$"
-      #time_key: time
-      #time_format: "%Y-%M-%dT%H:%M:%S.%L"
+      regex: '^\[(?<time>\S+)\] (?<message>((?<severity>(fatal|error|verbose|debug[0-9]?)):)?.*)$'
     parse_slurmlog2:
       type: parse_regex
       field: message
-      regex: "^(?<time>\S+ \S+) (?<message>(?<severity>(CRITICAL|ERROR|WARNING|INFO|DEBUG))(\(\S+\))?:.*)$"
-      #time_key: time
-      #time_format: "%Y-%M-%d %H:%M:%S,%L"
+      regex: '^(?<time>\S+ \S+) (?<message>(?<severity>(CRITICAL|ERROR|WARNING|INFO|DEBUG))(\(\S+\))?:.*)$'
+    add_cluster_info:
+      type: modify_fields
+      fields:
+        labels."cluster_name":
+          static_value: placeholder_clustername
+        labels."hostname":
+          static_value: placeholder_hostname
   service:
     pipelines:
       slurmlog_pipeline:
         receivers:
-        - slurmdbd
-        - slurmrestd
-        - slurmctld
-        - slurmd
+        - slurm_daemon
         processors:
         - parse_slurmlog
+        - add_cluster_info
       slurmlog2_pipeline:
         receivers:
-        - slurm_resume
-        - slurm_suspend
-        - slurm_sync
+        - slurm
         - setup
         processors:
         - parse_slurmlog2
+        - add_cluster_info


### PR DESCRIPTION
The main changes:

A. Labels added that contain the cluster name and (vm) hostname in each log. They start as placeholders in the cloud ops configuration but will be update at boot time by setup.py

B. The logging path added to the logging structure (as another label) the overall log names are generalized, since there’s no longer a need to have 6-7 different logNames it was shortened only 3, one for slurm daemons (which will be called slurm_daemon) and another for everything else slurm (thinking of putting this under the umbrella of just slurm to match legacy) and a third for the setup logs.

This allows the use of commands that can be filtered to hostname or cluster level with ease.

**How was this tested?** 
Deployed a VM instance and added the code change to the cluster directly.
a. Ensured code does not run if user does not have cloud-ops-agent running as a service

Manually changed the cloud-ops configuration to reflect proposed changes.
b. Verify configuration is valid and placeholders show as expected

Run a script changes as a single python function.
c. Verify the function edits the configuration and restarts as expected, with updated label values

As seen above testing was by enlarge manual, the script changes can only be added along with the configuration changes.
