### PR TITLE
Fix double quote in regex for config and add log paths

### DIFF
--- a/ansible/roles/cloudagents/templates/ops_agent.yaml.j2
+++ b/ansible/roles/cloudagents/templates/ops_agent.yaml.j2
@@ -18,47 +18,51 @@ logging:
       type: files
       include_paths:
       - /var/log/slurm/slurmdbd.log
+      record_log_file_path: true
     slurmrestd:
       type: files
       include_paths:
       - /var/log/slurm/slurmrestd.log
+      record_log_file_path: true
     slurmctld:
       type: files
       include_paths:
       - /var/log/slurm/slurmctld.log
+      record_log_file_path: true
     slurmd:
       type: files
       include_paths:
       - /var/log/slurm/slurmd-*.log
+      record_log_file_path: true
     slurm_resume:
       type: files
       include_paths:
       - /var/log/slurm/resume.log
+      record_log_file_path: true
     slurm_suspend:
       type: files
       include_paths:
       - /var/log/slurm/suspend.log
+      record_log_file_path: true
     slurm_sync:
       type: files
       include_paths:
       - /var/log/slurm/slurmsync.log
+      record_log_file_path: true
     setup:
       type: files
       include_paths:
       - /slurm/scripts/setup.log
+      record_log_file_path: true
   processors:
     parse_slurmlog:
       type: parse_regex
       field: message
-      regex: "^\[(?<time>\S+)\] (?<message>((?<severity>(fatal|error|verbose|debug[0-9]?)):)?.*)$"
-      #time_key: time
-      #time_format: "%Y-%M-%dT%H:%M:%S.%L"
+      regex: '^\[(?<time>\S+)\] (?<message>((?<severity>(fatal|error|verbose|debug[0-9]?)):)?.*)$'
     parse_slurmlog2:
       type: parse_regex
       field: message
-      regex: "^(?<time>\S+ \S+) (?<message>(?<severity>(CRITICAL|ERROR|WARNING|INFO|DEBUG))(\(\S+\))?:.*)$"
-      #time_key: time
-      #time_format: "%Y-%M-%d %H:%M:%S,%L"
+      regex: '^(?<time>\S+ \S+) (?<message>(?<severity>(CRITICAL|ERROR|WARNING|INFO|DEBUG))(\(\S+\))?:.*)$'
   service:
     pipelines:
       slurmlog_pipeline:


### PR DESCRIPTION
When using double quotes plus the \ key yaml will treat it as an escape sequence. For parsers this can be problematic. This change makes it single quotes instead, it also adds an additional label to the logs that gives the path of the log (makes it easier to filter specific logs).

Testing manually and logs are filtered identically with single-quotes vs double-quotes.