### PR TITLE
Updating selinux role to get around selinux module incompatibilities

### DIFF
--- a/ansible/roles/selinux/tasks/main.yml
+++ b/ansible/roles/selinux/tasks/main.yml
@@ -14,14 +14,26 @@
 # limitations under the License.
 
 - block:
-  - name: Disable SELinux
-    selinux:
-      configfile: '{{selinux_conf}}'
-      state: disabled
-      policy: targeted
-    register: status
+  - name: Check SELinux
+    stat:
+      path: "{{ selinux_conf }}"
+    register: stat_result
 
-  - name: Reboot
-    reboot:
-    when: status.reboot_required and reboot
+  - block:
+    - name: Ensure SELinux is set to disabled mode
+      ansible.builtin.lineinfile:
+        path: "{{ selinux_conf }}"
+        regexp: '^SELINUX='
+        line: SELINUX=disabled
+
+    - name: Ensure SELinux is set to targeted mode
+      ansible.builtin.lineinfile:
+        path: "{{ selinux_conf }}"
+        regexp: '^SELINUXTYPE='
+        line: SELINUXTYPE=targeted
+
+    - name: Reboot
+      reboot:
+      when: reboot
+    when: stat_result.stat.exists
   when: ansible_os_family == "RedHat"


### PR DESCRIPTION
The selinux ansible module seems to break fairly easily with Rocky Linux 8 (potentially other RHEL based distros).  I believe there is some compatibility issue with python3-libselinux and the ansible module (python misconfigs).

This change checks for the config file and hard sets the disable and targeted values within the file.  It assumes that it needs to be reboot ( does not check if anything was changed) and reboots unless the `reboot` variable is set to false.

This has been tested on a Slurm build on a base image of Rocky Linux 8.