### PR TITLE
Add check/mkdir for apt keyrings in nvidia-container role

### DIFF
--- a/ansible/roles/nvidia_container_toolkit_repo/defaults/main.yml
+++ b/ansible/roles/nvidia_container_toolkit_repo/defaults/main.yml
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+apt_keyring: /etc/apt/keyrings
 nvidia_gpg_key_url: https://nvidia.github.io/libnvidia-container/gpgkey
 nvidia_repo_url_deb: https://nvidia.github.io/libnvidia-container/stable/deb
-nvidia_gpg_key_deb: /etc/apt/keyrings/nvidia-container-toolkit-keyring.asc
+nvidia_gpg_key_deb: "{{ apt_keyring }}/nvidia-container-toolkit-keyring.asc"
 nvidia_repo_file_rpm: https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo

--- a/ansible/roles/nvidia_container_toolkit_repo/tasks/os/debian.yml
+++ b/ansible/roles/nvidia_container_toolkit_repo/tasks/os/debian.yml
@@ -13,6 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Check and create keyring folder
+  ansible.builtin.file:
+    path: "{{ apt_keyring }}"
+    state: directory
+    mode: '0755'
+
 - name: Collect Nvidia Container Repo GPG Key
   ansible.builtin.get_url:
     url: "{{ nvidia_gpg_key_url }}"


### PR DESCRIPTION
Adds keyring directory for OSs that do not have it by default.  Tested on Ubuntu 20.04 and 22.04, Deb 11 and12.