### PR TITLE
Fix to address changes to TF 6.2.0 subnetwork module

### DIFF
--- a/terraform/slurm_cluster/modules/_slurm_instance/README_TF.md
+++ b/terraform/slurm_cluster/modules/_slurm_instance/README_TF.md
@@ -67,7 +67,7 @@ No modules.
 | <a name="input_slurm_cluster_name"></a> [slurm\_cluster\_name](#input\_slurm\_cluster\_name) | Cluster name, used for resource naming. | `string` | n/a | yes |
 | <a name="input_slurm_instance_role"></a> [slurm\_instance\_role](#input\_slurm\_instance\_role) | Slurm instance type. Must be one of: controller; login; compute. | `string` | `null` | no |
 | <a name="input_static_ips"></a> [static\_ips](#input\_static\_ips) | List of static IPs for VM instances | `list(string)` | `[]` | no |
-| <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | Subnet to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
+| <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | Subnet to deploy to. Only one of network or subnetwork should be specified. | `string` | `null` | no |
 | <a name="input_subnetwork_project"></a> [subnetwork\_project](#input\_subnetwork\_project) | The project that subnetwork belongs to | `string` | `""` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | Zone where the instances should be created. If not specified, instances will be spread across available zones in the region. | `string` | `null` | no |
 

--- a/terraform/slurm_cluster/modules/_slurm_instance/variables.tf
+++ b/terraform/slurm_cluster/modules/_slurm_instance/variables.tf
@@ -30,7 +30,7 @@ variable "network" {
 variable "subnetwork" {
   description = "Subnet to deploy to. Only one of network or subnetwork should be specified."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "subnetwork_project" {


### PR DESCRIPTION
Fix was to set the subnetwork variable in the _instance_template to `null`.