### PR TITLE
Update nccl-plugin and rxdm versions and add --install-nccl to prolog

### DIFF
--- a/tools/prologs-epilogs/receive-data-path-manager-mega
+++ b/tools/prologs-epilogs/receive-data-path-manager-mega
@@ -39,6 +39,8 @@ if [[ ${SLURM_SCRIPT_CONTEXT} == "prolog_slurmd" ]]; then
 	export PATH=${PATH}:/usr/local/lib/google-cloud-sdk/bin/
 	gcloud auth configure-docker --quiet us-docker.pkg.dev 2>&1 &>/dev/null
 
+	rm -rf /var/lib/tcpxo/lib64 || true
+
 	# Install the nccl, nccl-net lib into /var/lib/tcpxo/lib64/.
 	docker run --rm --name nccl-installer \
 		--network=host \

--- a/tools/prologs-epilogs/receive-data-path-manager-mega
+++ b/tools/prologs-epilogs/receive-data-path-manager-mega
@@ -30,8 +30,8 @@ fi
 # ensure that dmabuf-import-helper is loaded
 modprobe import-helper
 
-NCCL_PLUGIN_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.4
-RXDM_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.10
+NCCL_PLUGIN_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.7
+RXDM_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.13
 RXDM_CONTAINER=receive-datapath-manager-"${SLURM_JOB_ID}"
 if [[ ${SLURM_SCRIPT_CONTEXT} == "prolog_slurmd" ]]; then
 	docker container list --filter "name=receive-datapath-manager-*" --quiet | xargs --no-run-if-empty docker container stop
@@ -44,7 +44,7 @@ if [[ ${SLURM_SCRIPT_CONTEXT} == "prolog_slurmd" ]]; then
 		--network=host \
 		-v /var/lib:/var/lib \
 		${NCCL_PLUGIN_IMAGE} \
-		install
+		install --install-nccl
 
 	# Modify NCCL env vars for Debian 12.
 	# /var/lib/tcpxo/lib64/nccl-env-profile.sh is written by the nccl-installer container

--- a/tools/prologs-epilogs/receive-data-path-manager-mega
+++ b/tools/prologs-epilogs/receive-data-path-manager-mega
@@ -39,7 +39,7 @@ if [[ ${SLURM_SCRIPT_CONTEXT} == "prolog_slurmd" ]]; then
 	export PATH=${PATH}:/usr/local/lib/google-cloud-sdk/bin/
 	gcloud auth configure-docker --quiet us-docker.pkg.dev 2>&1 &>/dev/null
 
-	rm -rf /var/lib/tcpxo/lib64 || true
+	rm -rf /var/lib/tcpxo/lib64
 
 	# Install the nccl, nccl-net lib into /var/lib/tcpxo/lib64/.
 	docker run --rm --name nccl-installer \


### PR DESCRIPTION
- Update NCCL and RxDM image to latest recommended versions (v1.0.7, and v1.0.13)
- add --install-nccl flag to libnccl installation command.  This installs newer version of libnccl (2.21.5), which is compatible with the NCCL and RxDM images

Tests performed:
- run llama3 training on A3-Mega with NCCL v1.0.7 and RxDM v1.0.13 (without --install-nccl flag in prolog script): results in segmentation faults
- run llama3 training on A3-Mega with NCCL v1.0.7 and RxDM v1.0.13 (with --install-nccl flag in prolog script): results in working run