### PR TITLE
Updating google-beta for instance template to allow for new nic-types

### DIFF
--- a/terraform/slurm_cluster/modules/_instance_template/README_TF.md
+++ b/terraform/slurm_cluster/modules/_instance_template/README_TF.md
@@ -28,14 +28,14 @@ limitations under the License.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.13.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.88 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 3.88 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 6.13.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 3.88 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 3.88 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 6.13.0 |
 
 ## Modules
 

--- a/terraform/slurm_cluster/modules/_instance_template/versions.tf
+++ b/terraform/slurm_cluster/modules/_instance_template/versions.tf
@@ -24,7 +24,7 @@ terraform {
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.88"
+      version = ">= 6.13.0"
     }
   }
   provider_meta "google" {


### PR DESCRIPTION
Switch to minimum version of 6.13.0 for instance_template as that is the minimum for using the MRDMA and IRDMA nic_types.

Testing by running updating the Toolkit to use the a4c3a89 ref of the slurm-gcp modules, and running against a few different Slurm integration tests

slurm-gcp-v6-ubuntu - passed
slurm-gcp-v6-static - passed
hpc-enterprise-slurm - passed
hcls - ongoing