### PR TITLE
Update `lustre_install` to false

### DIFF
--- a/ansible/roles/lustre/vars/ubuntu-20.04.yml
+++ b/ansible/roles/lustre/vars/ubuntu-20.04.yml
@@ -13,8 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-lustre_repo_url: https://downloads.whamcloud.com/public/lustre/latest-feature-release/ubuntu2004/client
+lustre_repo_url: https://downloads.whamcloud.com/public/lustre/lustre-2.15.0/ubuntu2004/client
 
 lustre_packages:
 - lustre-client-modules
 - lustre-client-utils
+
+lustre_install: false


### PR DESCRIPTION
This PR updates the lustre repository link for ubuntu20.04. The `latest-feature-release` brought up a 404 not found error.  `lustre-2.15.0` was the last URL to work so it is pinned. This PR also sets it not to install for Ubuntu20.04.