### PR TITLE
Add terraform setup to workflow config

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -37,6 +37,10 @@ jobs:
         python-version: '3.10'
         check-latest: true
         cache: 'pip'
+    - uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: "1.5.7"
+        terraform_wrapper: false
     - uses: terraform-linters/setup-tflint@v4
       with:
         tflint_version: v0.49.0


### PR DESCRIPTION
This PR adds terraform set-up to the pre-commit workflow config.

This will resolve pre-commits failing with `terraform: command not found`