### PR TITLE
Update A3-Mega with LL128 RxDM prolog

### DIFF
--- a/tools/prologs-epilogs/receive-data-path-manager-mega
+++ b/tools/prologs-epilogs/receive-data-path-manager-mega
@@ -30,8 +30,8 @@ fi
 # ensure that dmabuf-import-helper is loaded
 modprobe import-helper
 
-NCCL_PLUGIN_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.7
-RXDM_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.13
+NCCL_PLUGIN_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.8-1
+RXDM_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.14
 RXDM_CONTAINER=receive-datapath-manager-"${SLURM_JOB_ID}"
 if [[ ${SLURM_SCRIPT_CONTEXT} == "prolog_slurmd" ]]; then
 	docker container list --filter "name=receive-datapath-manager-*" --quiet | xargs --no-run-if-empty docker container stop
@@ -48,15 +48,17 @@ if [[ ${SLURM_SCRIPT_CONTEXT} == "prolog_slurmd" ]]; then
 		${NCCL_PLUGIN_IMAGE} \
 		install --install-nccl
 
-	# Modify NCCL env vars for Debian 12.
-	# /var/lib/tcpxo/lib64/nccl-env-profile.sh is written by the nccl-installer container
-	# above, and assumes interface names of eth{0..8}.
+        # Modify NCCL env vars for Debian 12.
+        # /var/lib/tcpxo/lib64/nccl-env-profile.sh is written by the nccl-installer container
+        # above, and assumes interface names of eth{0..8}.
 	if (grep -q "ID=debian" /etc/os-release && lsb_release -rs | grep -q "12"); then
 		cat >>/var/lib/tcpxo/lib64/nccl-env-profile.sh <<-EOF
-			export NCCL_FASTRAK_CTRL_DEV=enp0s12
-			export NCCL_FASTRAK_IFNAME=enp6s0,enp7s0,enp13s0,enp14s0,enp134s0,enp135s0,enp141s0,enp142s0
-			export NCCL_SOCKET_IFNAME=enp0s12
 			export NCCL_FASTRAK_LLCM_DEVICE_DIRECTORY=/dev/aperture_devices
+			export LD_LIBRARY_PATH=/var/lib/tcpxo/lib64:\${LD_LIBRARY_PATH}
+		EOF
+		cat >>/var/lib/tcpxo/lib64/nccl-env-profile-ll128.sh <<-EOF
+			export NCCL_FASTRAK_LLCM_DEVICE_DIRECTORY=/dev/aperture_devices
+			export LD_LIBRARY_PATH=/var/lib/tcpxo/lib64:\${LD_LIBRARY_PATH}
 		EOF
 	fi
 


### PR DESCRIPTION
There are now separate nccl-env-profiles for standard and ll128. They also now auto-detect which interfaces to use.