### PR TITLE
Reapply "Add python installation step to image building (#248)" (#251)

### DIFF
--- a/ansible/roles/python/files/slurm-gcp-requirements.txt
+++ b/ansible/roles/python/files/slurm-gcp-requirements.txt
@@ -5,7 +5,7 @@ certifi==2023.7.22
 charset-normalizer==3.2.0
 decorator==5.1.1
 docopt==0.6.2
-google-api-core==2.19.0
+google-api-core==2.24.1
 google-api-python-client==2.93.0
 google-auth==2.38.0
 google-auth-httplib2==0.2.0
@@ -13,10 +13,10 @@ google-cloud-bigquery==3.29.0
 google-cloud-core==2.4.1
 google-cloud-secret-manager==2.23.0
 google-cloud-storage==2.10.0
-google-cloud-tpu==1.10.0
+google-cloud-tpu==1.23.0
 google-crc32c==1.5.0
 google-resumable-media==2.5.0
-googleapis-common-protos==1.59.1
+googleapis-common-protos==1.67.0
 grpcio==1.70.0
 grpcio-status==1.70.0
 httplib2==0.22.0
@@ -31,7 +31,7 @@ pickleshare==0.7.5
 pipreqs==0.4.13
 prometheus-client==0.17.1
 prompt-toolkit==3.0.39
-proto-plus==1.22.3
+proto-plus==1.26.0
 protobuf==5.29.3
 ptyprocess==0.7.0
 pyasn1==0.5.0

--- a/ansible/roles/python/tasks/main.yml
+++ b/ansible/roles/python/tasks/main.yml
@@ -23,6 +23,31 @@
   - '{{ ansible_os_family|lower }}-{{ ansible_distribution_major_version }}.yml'
   - '{{ ansible_os_family|lower }}.yml'
 
+- name: Install Python
+  ansible.builtin.shell: |
+    #!/bin/bash
+
+    INSTALL_DIR="/slurm/python"
+    mkdir -p "${INSTALL_DIR}"
+    cd "${INSTALL_DIR}" || exit 1
+
+    curl -LO "https://www.python.org/ftp/python/3.13.1/Python-3.13.1.tgz"
+    tar -xzf "Python-3.13.1.tgz" -C "${INSTALL_DIR}"
+    cd "$INSTALL_DIR/Python-3.13.1" || exit 1
+    ./configure --prefix="/slurm/python"
+    make altinstall
+    cd "${INSTALL_DIR}" || exit 1
+    rm -rf Python-3.13.1*
+  args:
+    executable: /bin/bash
+    creates: /slurm/python/bin/python3.13
+
+- name: Create virtualenv for tool
+  ansible.builtin.pip:
+    name: pip==25.0
+    virtualenv: "/slurm/python/venv"
+    virtualenv_command: /slurm/python/bin/python3.13 -m venv --copies
+
 - name: Install Packages
   package:
     name: '{{python_packages}}'
@@ -33,34 +58,20 @@
     cmd: alternatives --set python3 /usr/bin/python3.8
   when: python38_installed
 
-- name: Upgrade Pip
-  pip:
-    name:
-    - pip
-    extra_args: --upgrade {{ extra_pip_args }}
-    executable: pip3
-    state: present
-
 - name: Copy Pip Requirements File
   copy:
-    src: '{{ item | basename }}'
-    dest: /tmp/{{ item | basename }}
-  with_first_found:
-  - '{{ ansible_distribution|lower }}-{{ ansible_distribution_version }}_requirements.txt'
-  - '{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version }}_requirements.txt'
-  - '{{ ansible_distribution|lower }}_requirements.txt'
-  - '{{ ansible_os_family|lower }}-{{ ansible_distribution_version }}_requirements.txt'
-  - '{{ ansible_os_family|lower }}-{{ ansible_distribution_major_version }}_requirements.txt'
-  - '{{ ansible_os_family|lower }}_requirements.txt'
+    src: ../files/slurm-gcp-requirements.txt
+    dest: /tmp/requirements.txt
   register: requirements_file
 
+#TODO investigate whether this workaround is still needed
 - name: Install pyyaml workaround
   shell:
     cmd: pip3 install "Cython<3.0" pyyaml --no-build-isolation {{ extra_pip_args }}
 
 - name: Install Pip Packages
   pip:
-    requirements: '{{ requirements_file.results[0].dest }}'
+    requirements: /tmp/requirements.txt
     extra_args: --upgrade --ignore-installed {{ extra_pip_args }}
-    executable: pip3
+    virtualenv: "/slurm/python/venv"
     state: present


### PR DESCRIPTION
This commit reapplies b53ff959bb57cad41b0b35bd35e2b0f39441b31d. Since 6.8.10 tags have now been fixed and a new tag will be rolled based on this commit.