### PR TITLE
Add Slurm-gcp support for Ubuntu 24.04

### DIFF
--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -28,6 +28,11 @@ Vagrant.configure("2") do |config|
     ubuntu2204.vm.box = "generic/ubuntu2204"
   end
 
+  # Ubuntu 24.04 LTS
+  config.vm.define "ubuntu2404" do |ubuntu2404|
+    ubuntu2204.vm.box = "generic/ubuntu2404"
+  end
+
   # Debian 10
   config.vm.define "debian10" do |debian10|
     debian10.vm.box = "generic/debian10"

--- a/ansible/docker-playbook.yml
+++ b/ansible/docker-playbook.yml
@@ -106,9 +106,9 @@
   - name: Check Support on Ubuntu
     when: ansible_distribution == "Ubuntu"
     ansible.builtin.assert:
-      that: ansible_distribution_version is version('20.04', '==') or ansible_distribution_version is version('22.04', '==')
+      that: ansible_distribution_version is version('20.04', '==') or ansible_distribution_version is version('22.04', '==') or ansible_distribution_version is version('24.04', '==')
       fail_msg: |
-        When building Slurm-GCP on Ubuntu, use release 20.04 or 22.04
+        When building Slurm-GCP on Ubuntu, use release 20.04/22.04/24.04
 
   roles:
   - motd

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -179,10 +179,7 @@
   - role: gcsfuse
     when:
     - install_gcsfuse
-    - ansible_architecture == "x86_64"
   - role: cloudagents
-    when:
-    - ansible_architecture == "x86_64"
   - logrotate
   - python
   - role: ldap

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -114,9 +114,9 @@
   - name: Check Support on Ubuntu
     when: ansible_distribution == "Ubuntu"
     ansible.builtin.assert:
-      that: ansible_distribution_version is version('20.04', '==') or ansible_distribution_version is version('22.04', '==')
+      that: ansible_distribution_version is version('20.04', '==') or ansible_distribution_version is version('22.04', '==') or ansible_distribution_version is version('24.04', '==')
       fail_msg: |
-        When building Slurm-GCP on Ubuntu, use release 20.04 or 22.04
+        When building Slurm-GCP on Ubuntu, use release 20.04/22.04/24.04
   - name: Check Lustre Install Options
     ansible.builtin.assert:
       that: not (install_lustre and install_managed_lustre)

--- a/ansible/roles/cgroups/vars/ubuntu-24.04.yml
+++ b/ansible/roles/cgroups/vars/ubuntu-24.04.yml
@@ -1,0 +1,25 @@
+---
+# Copyright (C) SchedMD LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cgroup_packages:
+- libcgroup2
+- libcgroup-dev
+- libpam-cgroup
+- libdbus-1-dev
+
+cgroup_grub_cmdline_linux:
+- systemd.unified_cgroup_hierarchy=1
+- cgroup_enable=memory
+- swapaccount=1

--- a/ansible/roles/common/vars/ubuntu-24.04.yml
+++ b/ansible/roles/common/vars/ubuntu-24.04.yml
@@ -1,0 +1,44 @@
+---
+# Copyright (C) SchedMD LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+common_packages:
+- autoconf
+- automake
+- bash-completion
+- build-essential
+- clang
+- curl
+- doxygen
+- emacs
+- g++
+- gcc
+- git
+- graphviz
+- htop
+- iputils-ping
+- jq
+- libssl-dev
+- libtool
+- lynx
+- make
+- pciutils
+- pdsh
+- pkg-config
+- python3
+- python3-gdbm
+- tmux
+- unzip
+- valgrind
+- vim

--- a/ansible/roles/lustre/vars/ubuntu-24.04.yml
+++ b/ansible/roles/lustre/vars/ubuntu-24.04.yml
@@ -1,0 +1,20 @@
+---
+# Copyright (C) SchedMD LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+lustre_repo_url: https://downloads.whamcloud.com/public/lustre/latest-release/ubuntu2404/client
+
+lustre_packages:
+- lustre-client-modules
+- lustre-client-utils

--- a/ansible/roles/pmix/vars/ubuntu-24.04.yml
+++ b/ansible/roles/pmix/vars/ubuntu-24.04.yml
@@ -1,0 +1,18 @@
+---
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+pmix_dependencies:
+- libevent-dev
+- libhwloc-dev

--- a/ansible/roles/python/files/slurm-gcp-requirements.txt
+++ b/ansible/roles/python/files/slurm-gcp-requirements.txt
@@ -39,7 +39,7 @@ pyasn1-modules==0.3.0
 Pygments==2.15.1
 pyparsing==3.1.0
 python-dateutil==2.8.2
-PyYAML==6.0.1
+PyYAML==6.0.2
 requests==2.31.0
 rsa==4.9
 six==1.16.0

--- a/ansible/roles/python/files/ubuntu-24.04_requirements.txt
+++ b/ansible/roles/python/files/ubuntu-24.04_requirements.txt
@@ -1,0 +1,8 @@
+addict~=2.0
+google-api-python-client~=2.0
+google-cloud-bigquery~=2.0
+google-cloud-secret-manager~=2.0
+google-cloud-storage~=2.0
+google-cloud-tpu~=1.10.0
+more-executors~=2.0
+prometheus-client~=0.16

--- a/ansible/roles/python/tasks/main.yml
+++ b/ansible/roles/python/tasks/main.yml
@@ -64,11 +64,6 @@
     dest: /tmp/requirements.txt
   register: requirements_file
 
-#TODO investigate whether this workaround is still needed
-- name: Install pyyaml workaround
-  shell:
-    cmd: pip3 install "Cython<3.0" pyyaml --no-build-isolation {{ extra_pip_args }}
-
 - name: Install Pip Packages
   pip:
     requirements: /tmp/requirements.txt

--- a/ansible/roles/python/vars/ubuntu-24.04.yml
+++ b/ansible/roles/python/vars/ubuntu-24.04.yml
@@ -1,0 +1,20 @@
+---
+# Copyright (C) SchedMD LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+python_packages:
+- python3
+- python3-pip
+- python3-setuptools
+- python3-virtualenv

--- a/ansible/roles/slurm/vars/ubuntu-24.04.yml
+++ b/ansible/roles/slurm/vars/ubuntu-24.04.yml
@@ -1,0 +1,45 @@
+---
+# Copyright (C) SchedMD LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+slurm_packages:
+- bind9utils
+- cifs-utils
+- hwloc
+- libcurl4-gnutls-dev
+- libevent-dev
+- libgtk2.0-dev
+- libhdf5-dev
+- libhttp-parser-dev
+- libhwloc-dev
+- libibumad-dev
+- libjson-c-dev
+- libjwt-dev
+- liblua5.3-dev
+- liblz4-dev
+- libncurses-dev
+- libnuma-dev
+- libpam0g-dev
+- libperl-dev
+- libreadline-dev
+- librrd-dev
+- libssh2-1-dev
+- libssl-dev
+- libyaml-dev
+- lua5.3
+- man2html-base
+- numactl
+- rrdtool
+- systemd
+- systemd-sysv

--- a/ansible/tf-playbook.yml
+++ b/ansible/tf-playbook.yml
@@ -61,7 +61,8 @@
         ) or
         ( ansible_distribution == "Ubuntu" and
           (ansible_distribution_version is version('20.04', '==') or
-          ansible_distribution_version is version('22.04', '=='))
+          ansible_distribution_version is version('22.04', '==') or
+          ansible_distribution_version is version('24.04', '=='))
         )
       msg: >
         OS ansible_distribution version ansible_distribution_major_version is not
@@ -71,7 +72,7 @@
           - Rocky 8
           - RedHat 8, 9
           - Debian 10, 11
-          - Ubuntu 20.04, 22.04
+          - Ubuntu 20.04, 22.04, 24.04
   - name: Minimum Ansible Version Check
     assert:
       that: ansible_version.full is version_compare({{min_ansible_version}}, '>=')

--- a/packer/builds/ubuntu-2404-lts-arm64.hcl
+++ b/packer/builds/ubuntu-2404-lts-arm64.hcl
@@ -1,0 +1,41 @@
+# Copyright (C) SchedMD LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# GENERAL #
+###########
+
+project_id = "<PROJECT_ID>"
+zone       = "us-central1-a"
+
+#########
+# IMAGE #
+#########
+
+# NOTE: Your Project ID will be automatically appended
+source_image_project_id = "ubuntu-os-cloud"
+
+#source_image        = null
+source_image_family = "ubuntu-2404-lts-arm64"
+
+machine_type = "t2a-standard-16"
+
+# *NOT* intended for production use
+# skip_create_image = true
+
+#############
+# PROVISION #
+#############
+
+# slurm_version = null

--- a/packer/builds/ubuntu-2404-lts.hcl
+++ b/packer/builds/ubuntu-2404-lts.hcl
@@ -1,0 +1,39 @@
+# Copyright (C) SchedMD LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# GENERAL #
+###########
+
+project_id = "<PROJECT_ID>"
+zone       = "us-central1-a"
+
+#########
+# IMAGE #
+#########
+
+# NOTE: Your Project ID will be automatically appended
+source_image_project_id = "ubuntu-os-cloud"
+
+#source_image        = null
+source_image_family = "ubuntu-2404-lts"
+
+# *NOT* intended for production use
+# skip_create_image = true
+
+#############
+# PROVISION #
+#############
+
+# slurm_version = null

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -39,7 +39,7 @@ pyasn1-modules==0.3.0
 Pygments==2.15.1
 pyparsing==3.1.0
 python-dateutil==2.8.2
-PyYAML==6.0.1
+PyYAML==6.0.2
 requests==2.31.0
 rsa==4.9
 six==1.16.0

--- a/third_party/ansible/roles/cuda/vars/ubuntu-24.04.yml
+++ b/third_party/ansible/roles/cuda/vars/ubuntu-24.04.yml
@@ -1,0 +1,4 @@
+---
+cuda_repo_subfolder: ubuntu2404
+
+# vim:ft=ansible:


### PR DESCRIPTION
Added support for Ubuntu 24.04

- uses cgroupsv2 plugin
- PyYAML version bumped up