### PR TITLE
Install gcsfuse and op agent on Ubuntu 24 ARM64

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -160,7 +160,7 @@
   - role: gcsfuse
     when:
     - install_gcsfuse
-    - ansible_architecture == "x86_64"
+    - ansible_architecture == "x86_64" or (ansible_distribution == "Ubuntu" and ansible_distribution_version is version('24.04', '=='))
   - role: cloudagents
     when:
     - ansible_architecture == "x86_64" or (ansible_distribution == "Ubuntu" and ansible_distribution_version is version('24.04', '=='))

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -163,7 +163,7 @@
     - ansible_architecture == "x86_64"
   - role: cloudagents
     when:
-    - ansible_architecture == "x86_64"
+    - ansible_architecture == "x86_64" or (ansible_distribution == "Ubuntu" and ansible_distribution_version is version('24.04', '=='))
   - logrotate
   - python
   - role: ldap


### PR DESCRIPTION
This change adds support for gcsfuse and cloud ops agent on the slurm-gcp install for Ubuntu 24 for ARM64 processors.  This was tested by building a new image and making sure that it didn't fail during the install process.  