### PR TITLE
Adding managed Lustre role to slurm image building - DO NOT MERGE

### DIFF
--- a/ansible/group_vars/os_debian.yml
+++ b/ansible/group_vars/os_debian.yml
@@ -13,5 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-kernel_package: linux-image-cloud-{{ deb_arch }}
+kernel_packages:
+- linux-image*
 kernel_headers_package: linux-headers-cloud-{{ deb_arch }}

--- a/ansible/group_vars/os_debian.yml
+++ b/ansible/group_vars/os_debian.yml
@@ -14,5 +14,5 @@
 # limitations under the License.
 
 kernel_packages:
-- linux-image*
+- linux-image-cloud-{{ deb_arch }}
 kernel_headers_package: linux-headers-cloud-{{ deb_arch }}

--- a/ansible/group_vars/os_ubuntu.yml
+++ b/ansible/group_vars/os_ubuntu.yml
@@ -14,5 +14,8 @@
 # limitations under the License.
 
 kernel_packages:
-- linux-image*
+- linux-modules-nvidia-*-server-open-gcp
+- linux-image-gcp
+- linux-headers-gcp
+- linux-gcp
 kernel_headers_package: linux-headers-gcp

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -129,7 +129,11 @@
       fail_msg: |
         Managed Lustre is only compatible with Rocky 8, Ubuntu 20.04, and Ubuntu 22.04
   - name: Freeze kernel before running playbook
-    ansible.builtin.shell: "apt-mark hold {{ item }}"
+    ansible.builtin.command:
+      argv:
+      - apt-mark
+      - hold
+      - "{{ item }}"
     loop: "{{ kernel_packages }}"
     when: ansible_os_family == "Debian"
 
@@ -187,7 +191,11 @@
 
   post_tasks:
   - name: Re-enable kernel upgrades by apt-get upgrade
-    ansible.builtin.shell: "apt-mark unhold {{ item }}"
+    ansible.builtin.command:
+      argv:
+      - apt-mark
+      - unhold
+      - "{{ item }}"
     loop: "{{ kernel_packages }}"
     when:
     - ansible_os_family == "Debian"

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -56,6 +56,7 @@
     install_cuda: true
     install_ompi: true
     install_lustre: true
+    install_managed_lustre: false
     install_gcsfuse: true
     install_pmix: true
     install_pyxis: true
@@ -116,11 +117,21 @@
       that: ansible_distribution_version is version('20.04', '==') or ansible_distribution_version is version('22.04', '==')
       fail_msg: |
         When building Slurm-GCP on Ubuntu, use release 20.04 or 22.04
+  - name: Check Lustre Install Options
+    ansible.builtin.assert:
+      that: not (install_lustre and install_managed_lustre)
+      fail_msg: |
+        install_lustre and install_managed_lustre are mutually exclusive Options
+  - name: Check Managed Lustre Install Options
+    when: install_managed_lustre
+    ansible.builtin.assert:
+      that: (ansible_distribution == "Ubuntu" and (ansible_distribution_version is version('20.04', '==') or ansible_distribution_version is version('22.04', '=='))) or (ansible_distribution == "Rocky" and ansible_distribution_major_version is version('8', '=='))
+      fail_msg: |
+        Managed Lustre is only compatible with Rocky 8, Ubuntu 20.04, and Ubuntu 22.04
   - name: Freeze kernel before running playbook
+    ansible.builtin.shell: "apt-mark hold {{ item }}"
+    loop: "{{ kernel_packages }}"
     when: ansible_os_family == "Debian"
-    ansible.builtin.dpkg_selections:
-      name: "{{ kernel_package }}"
-      selection: hold
 
   roles:
   - motd
@@ -157,6 +168,10 @@
     when:
     - install_lustre
     - ansible_architecture == "x86_64"
+  - role: managed_lustre
+    when:
+    - install_managed_lustre
+    - ansible_architecture == "x86_64"
   - role: gcsfuse
     when:
     - install_gcsfuse
@@ -172,9 +187,8 @@
 
   post_tasks:
   - name: Re-enable kernel upgrades by apt-get upgrade
+    ansible.builtin.shell: "apt-mark unhold {{ item }}"
+    loop: "{{ kernel_packages }}"
     when:
     - ansible_os_family == "Debian"
     - allow_kernel_upgrades
-    ansible.builtin.dpkg_selections:
-      name: "{{ kernel_package }}"
-      selection: install

--- a/ansible/roles/managed_lustre/defaults/main.yml
+++ b/ansible/roles/managed_lustre/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-kernel_packages:
-- linux-image*
-kernel_headers_package: linux-headers-gcp
+install_managed_lustre: false

--- a/ansible/roles/managed_lustre/tasks/main.yml
+++ b/ansible/roles/managed_lustre/tasks/main.yml
@@ -1,0 +1,58 @@
+---
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Include OS Family Dependent Vars
+  ansible.builtin.include_vars: '{{ item }}'
+  with_first_found:
+  - '{{ ansible_distribution|lower }}-{{ ansible_distribution_version }}.yml'
+  - '{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version }}.yml'
+  - '{{ ansible_distribution|lower }}.yml'
+  - '{{ ansible_os_family|lower }}-{{ ansible_distribution_version }}.yml'
+  - '{{ ansible_os_family|lower }}-{{ ansible_distribution_major_version }}.yml'
+  - '{{ ansible_os_family|lower }}.yml'
+
+- name: Include OS Family Dependent Tasks
+  include_tasks: '{{ item }}'
+  with_first_found:
+  - os/{{ ansible_distribution|lower }}-{{ ansible_distribution_version }}.yml
+  - os/{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version }}.yml
+  - os/{{ ansible_distribution|lower }}.yml
+  - os/{{ ansible_os_family|lower }}-{{ ansible_distribution_version }}.yml
+  - os/{{ ansible_os_family|lower }}-{{ ansible_distribution_major_version }}.yml
+  - os/{{ ansible_os_family|lower }}.yml
+  when: install_managed_lustre
+
+- name: Wait for DPKG Locks
+  ansible.builtin.shell: >
+    while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do
+      sleep 5
+    done
+  with_items:
+  - lock
+  - lock-frontend
+  when:
+  - install_managed_lustre
+  - ansible_os_family == 'Debian'
+
+- name: Install Managed Lustre Client
+  ansible.builtin.package:
+    name: '{{ managed_lustre_packages }}'
+    state: present
+  when: install_managed_lustre
+
+- name: Skip Managed Lustre install
+  ansible.builtin.debug:
+    msg: Managed Lustre install has been disabled for this OS
+  when: not install_managed_lustre

--- a/ansible/roles/managed_lustre/tasks/os/debian.yml
+++ b/ansible/roles/managed_lustre/tasks/os/debian.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-kernel_packages:
-- linux-image*
-kernel_headers_package: linux-headers-gcp
+- name: Add gpg key for Managed Lustre Client repo
+  ansible.builtin.get_url:
+    url: https://us-apt.pkg.dev/doc/repo-signing-key.gpg
+    dest: /etc/apt/keyrings/lustre-client.asc
+    mode: '0644'
+    force: true
+
+- name: Install Managed Lustre Client Repo
+  ansible.builtin.apt_repository:
+    filename: lustre-client
+    repo: deb [ signed-by=/etc/apt/keyrings/lustre-client.asc ] {{ managed_lustre_repo_url }} lustre-client-ubuntu-{{ ansible_distribution_release }} main
+    state: present
+    update_cache: true

--- a/ansible/roles/managed_lustre/tasks/os/redhat.yml
+++ b/ansible/roles/managed_lustre/tasks/os/redhat.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-kernel_packages:
-- linux-image*
-kernel_headers_package: linux-headers-gcp
+- name: Install Managed Lustre Client Repo
+  ansible.builtin.yum_repository:
+    name: lustre-client-rocky-8
+    description: Lustre Client
+    baseurl: '{{ lustre_repo_url }}'
+    enabled: true
+    gpgcheck: false

--- a/ansible/roles/managed_lustre/vars/redhat-8.yml
+++ b/ansible/roles/managed_lustre/vars/redhat-8.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-kernel_packages:
-- linux-image*
-kernel_headers_package: linux-headers-gcp
+lustre_repo_url: https://us-yum.pkg.dev/projects/lustre-client-binaries/lustre-client-rocky-8
+managed_lustre_packages:
+- kmod-lustre-client
+- lustre-client

--- a/ansible/roles/managed_lustre/vars/ubuntu-20.04.yml
+++ b/ansible/roles/managed_lustre/vars/ubuntu-20.04.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-kernel_packages:
-- linux-image*
-kernel_headers_package: linux-headers-gcp
+managed_lustre_repo_url: https://us-apt.pkg.dev/projects/lustre-client-binaries
+managed_lustre_packages:
+- lustre-client-modules-{{ ansible_kernel }}
+- lustre-client-utils

--- a/ansible/roles/managed_lustre/vars/ubuntu-22.04.yml
+++ b/ansible/roles/managed_lustre/vars/ubuntu-22.04.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-kernel_packages:
-- linux-image*
-kernel_headers_package: linux-headers-gcp
+managed_lustre_repo_url: https://us-apt.pkg.dev/projects/lustre-client-binaries
+managed_lustre_packages:
+- lustre-client-modules-{{ ansible_kernel }}
+- lustre-client-utils


### PR DESCRIPTION
This creates a separate role `managed_lustre` for slurm-gcp that installs the GCP client modules.  It is mutually-exclusive with the current lustre install and is only available on Ubuntu 22.04, 20.04 and Rocky 8 for the time being.

This PR also fixes the kernel update logic by holding all kernel packages as they can sneak in if another metapackage upgraded by `apt install upgrade` or `apt install dist-upgrade` requires the new kernel package.  The kernel install is not seen as an 'upgrade' so it isn't caught by dpkg selection holds or apt mark holds.

Changes from PR review tested on A3U cluster successfully (kernel version was maintained after Slurm install)