### PR TITLE
Add option for GKE compatible managed lustre instances

### DIFF
--- a/ansible/roles/managed_lustre/defaults/main.yml
+++ b/ansible/roles/managed_lustre/defaults/main.yml
@@ -14,3 +14,4 @@
 # limitations under the License.
 
 install_managed_lustre: false
+managed_lustre_port: 988

--- a/ansible/roles/managed_lustre/tasks/main.yml
+++ b/ansible/roles/managed_lustre/tasks/main.yml
@@ -41,6 +41,15 @@
       - os/{{ ansible_os_family|lower }}.yml
   when: install_managed_lustre
 
+- name: Update lnet to use GKE compatible port
+  when: managed_lustre_port | int != 988
+  ansible.builtin.lineinfile:
+    src: lnet.conf.j2
+    dest: /etc/modprobe.d/lnet.conf
+    owner: root
+    group: root
+    mode: '0644'
+
 - name: Wait for DPKG Locks
   ansible.builtin.shell: >
     while fuser /var/lib/dpkg/{{ item }} >/dev/null 2>&1; do

--- a/ansible/roles/managed_lustre/templates/lnet.conf.j2
+++ b/ansible/roles/managed_lustre/templates/lnet.conf.j2
@@ -1,0 +1,1 @@
+options lnet accept_port={{managed_lustre_port}}


### PR DESCRIPTION
Updates `/etc/modprobe.d/lnet.conf` to change lnet listening port for GKE compatible managed lustre instances.