### PR TITLE
Update to add gcp-64k kernel packages to compatibility for holding

### DIFF
--- a/ansible/group_vars/os_ubuntu.yml
+++ b/ansible/group_vars/os_ubuntu.yml
@@ -13,9 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+kernel_append: "{{ '-64k' if '64k' in ansible_kernel else '' }}"
 kernel_packages:
-- linux-modules-nvidia-*-server-open-gcp
-- linux-image-gcp
-- linux-headers-gcp
-- linux-gcp
-kernel_headers_package: linux-headers-gcp
+- linux-modules-nvidia-*-server-open-gcp{{kernel_append}}
+- linux-image-gcp{{kernel_append}}
+- linux-headers-gcp{{kernel_append}}
+- linux-gcp{{kernel_append}}
+kernel_headers_package: linux-headers-gcp{{kernel_append}}


### PR DESCRIPTION
On the new accelerator images for ARM64, we use the 64k version of the kernel packages.  Our original list did not check for this so the kernels were being upgraded accidentally.  This broke the build chain.  This checks for the `-64k` postfix on the kernel packages and adjusts the names accordingly.

Ultimately we should figure out a more intelligent way of listing out the current metapackages and holding them.