### PR TITLE
Update to managed_lustre and lustre roles to respect install setting

### DIFF
--- a/ansible/roles/lustre/defaults/main.yml
+++ b/ansible/roles/lustre/defaults/main.yml
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-lustre_install: true
+install_lustre: true

--- a/ansible/roles/lustre/tasks/main.yml
+++ b/ansible/roles/lustre/tasks/main.yml
@@ -14,25 +14,32 @@
 # limitations under the License.
 
 - name: Include OS Family Dependent Vars
-  ansible.builtin.include_vars: '{{ item }}'
-  with_first_found:
-  - '{{ ansible_distribution|lower }}-{{ ansible_distribution_version }}.yml'
-  - '{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version }}.yml'
-  - '{{ ansible_distribution|lower }}.yml'
-  - '{{ ansible_os_family|lower }}-{{ ansible_distribution_version }}.yml'
-  - '{{ ansible_os_family|lower }}-{{ ansible_distribution_major_version }}.yml'
-  - '{{ ansible_os_family|lower }}.yml'
+  ansible.builtin.include_vars: "{{ lookup('ansible.builtin.first_found', params) }}"
+  vars:
+    params:
+      files:
+      - '{{ ansible_distribution|lower }}-{{ ansible_distribution_version }}.yml'
+      - '{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version }}.yml'
+      - '{{ ansible_distribution|lower }}.yml'
+      - '{{ ansible_os_family|lower }}-{{ ansible_distribution_version }}.yml'
+      - '{{ ansible_os_family|lower }}-{{ ansible_distribution_major_version }}.yml'
+      - '{{ ansible_os_family|lower }}.yml'
+      paths:
+      - 'vars'
+  when: install_lustre
 
 - name: Include OS Family Dependent Tasks
-  include_tasks: '{{ item }}'
-  with_first_found:
-  - os/{{ ansible_distribution|lower }}-{{ ansible_distribution_version }}.yml
-  - os/{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version }}.yml
-  - os/{{ ansible_distribution|lower }}.yml
-  - os/{{ ansible_os_family|lower }}-{{ ansible_distribution_version }}.yml
-  - os/{{ ansible_os_family|lower }}-{{ ansible_distribution_major_version }}.yml
-  - os/{{ ansible_os_family|lower }}.yml
-  when: lustre_install
+  ansible.builtin.include_tasks: "{{ lookup('ansible.builtin.first_found', params) }}"
+  vars:
+    params:
+      files:
+      - os/{{ ansible_distribution|lower }}-{{ ansible_distribution_version }}.yml
+      - os/{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version }}.yml
+      - os/{{ ansible_distribution|lower }}.yml
+      - os/{{ ansible_os_family|lower }}-{{ ansible_distribution_version }}.yml
+      - os/{{ ansible_os_family|lower }}-{{ ansible_distribution_major_version }}.yml
+      - os/{{ ansible_os_family|lower }}.yml
+  when: install_lustre
 
 - name: Wait for DPKG Locks
   ansible.builtin.shell: >
@@ -43,16 +50,16 @@
   - lock
   - lock-frontend
   when:
-  - lustre_install
+  - install_lustre
   - ansible_os_family == 'Debian'
 
 - name: Install Lustre Client
   ansible.builtin.package:
     name: '{{ lustre_packages }}'
     state: present
-  when: lustre_install
+  when: install_lustre
 
 - name: Skip Lustre install
   ansible.builtin.debug:
     msg: Lustre install has been disabled for this OS
-  when: not lustre_install
+  when: not install_lustre

--- a/ansible/roles/managed_lustre/tasks/main.yml
+++ b/ansible/roles/managed_lustre/tasks/main.yml
@@ -14,24 +14,31 @@
 # limitations under the License.
 
 - name: Include OS Family Dependent Vars
-  ansible.builtin.include_vars: '{{ item }}'
-  with_first_found:
-  - '{{ ansible_distribution|lower }}-{{ ansible_distribution_version }}.yml'
-  - '{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version }}.yml'
-  - '{{ ansible_distribution|lower }}.yml'
-  - '{{ ansible_os_family|lower }}-{{ ansible_distribution_version }}.yml'
-  - '{{ ansible_os_family|lower }}-{{ ansible_distribution_major_version }}.yml'
-  - '{{ ansible_os_family|lower }}.yml'
+  ansible.builtin.include_vars: "{{ lookup('ansible.builtin.first_found', params) }}"
+  vars:
+    params:
+      files:
+      - '{{ ansible_distribution|lower }}-{{ ansible_distribution_version }}.yml'
+      - '{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version }}.yml'
+      - '{{ ansible_distribution|lower }}.yml'
+      - '{{ ansible_os_family|lower }}-{{ ansible_distribution_version }}.yml'
+      - '{{ ansible_os_family|lower }}-{{ ansible_distribution_major_version }}.yml'
+      - '{{ ansible_os_family|lower }}.yml'
+      paths:
+      - 'vars'
+  when: install_managed_lustre
 
 - name: Include OS Family Dependent Tasks
-  include_tasks: '{{ item }}'
-  with_first_found:
-  - os/{{ ansible_distribution|lower }}-{{ ansible_distribution_version }}.yml
-  - os/{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version }}.yml
-  - os/{{ ansible_distribution|lower }}.yml
-  - os/{{ ansible_os_family|lower }}-{{ ansible_distribution_version }}.yml
-  - os/{{ ansible_os_family|lower }}-{{ ansible_distribution_major_version }}.yml
-  - os/{{ ansible_os_family|lower }}.yml
+  ansible.builtin.include_tasks: "{{ lookup('ansible.builtin.first_found', params) }}"
+  vars:
+    params:
+      files:
+      - os/{{ ansible_distribution|lower }}-{{ ansible_distribution_version }}.yml
+      - os/{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version }}.yml
+      - os/{{ ansible_distribution|lower }}.yml
+      - os/{{ ansible_os_family|lower }}-{{ ansible_distribution_version }}.yml
+      - os/{{ ansible_os_family|lower }}-{{ ansible_distribution_major_version }}.yml
+      - os/{{ ansible_os_family|lower }}.yml
   when: install_managed_lustre
 
 - name: Wait for DPKG Locks

--- a/ansible/roles/managed_lustre/tasks/os/redhat.yml
+++ b/ansible/roles/managed_lustre/tasks/os/redhat.yml
@@ -17,6 +17,6 @@
   ansible.builtin.yum_repository:
     name: lustre-client-rocky-8
     description: Lustre Client
-    baseurl: '{{ lustre_repo_url }}'
+    baseurl: '{{ managed_lustre_repo_url }}'
     enabled: true
     gpgcheck: false

--- a/ansible/roles/managed_lustre/vars/redhat-8.yml
+++ b/ansible/roles/managed_lustre/vars/redhat-8.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-lustre_repo_url: https://us-yum.pkg.dev/projects/lustre-client-binaries/lustre-client-rocky-8
+managed_lustre_repo_url: https://us-yum.pkg.dev/projects/lustre-client-binaries/lustre-client-rocky-8
 managed_lustre_packages:
 - kmod-lustre-client
 - lustre-client


### PR DESCRIPTION
There was an issue using `install_managed_lustre: false` setting with Ubuntu 24, because a file did not exist for it in the managed_lustre/vars folder.  The playbook would fail because it always searches for the files when using `when_first_found`. `when_first_found` always runs prior to a `when` condition being evaluated

At a large scale this means that anytime a `install_<role>` variable is set false and that role has a `with_first_found` and an incompatible OS, the playbook will fail.  To prevent this, this PR moves the file search inline, so it is evaluated after the `when` condition.

Additionally, there are some minor cleanups that occurred.

Ultimately this should become a best practice for all the roles that use the include_vars/tasks.