### PR TITLE
cloud.md

### DIFF
--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -21,27 +21,15 @@ taken into account. This guide will cover them and their recommended solutions.
 
 There are two deployment methods for cloud cluster management:
 
-- [GCP Marketplace](#gcp-marketplace)
 - [Terraform](#terraform)
-
-## GCP Marketplace
-
-This deployment method leverages
-[GCP Marketplace](./glossary.md#gcp-marketplace) to make setting up clusters a
-breeze without leaving your browser. While this method is simpler and less
-flexible, it is great for exploring what `slurm-gcp` is!
-
-See the [Marketplace Guide](./marketplace.md) for setup instructions and more
-information.
 
 ## Terraform
 
 This deployment method leverages [Terraform](./glossary.md#terraform) to deploy
 and manage cluster infrastructure. While this method can be more complex, it is
-a robust option. `slurm-gcp` provides terraform modules that enables you to
-create a Slurm cluster with ease.
+a robust option. Cluster toolkit provides modules that enables you to create a Slurm cluster with ease.
 
-See the [slurm_cluster module](../terraform/slurm_cluster/README.md) for
+See the [Cluster toolkit](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/README.md) for
 details.
 
 If you are unfamiliar with [terraform](./glossary.md#terraform), then please
@@ -51,15 +39,18 @@ to get you familiar.
 
 ### Quickstart Examples
 
-See the [test cluster][test-cluster] example for an extensible and robust
-example. It can be configured to handle creation of all supporting resources
+See the [toolkit_quickstart][quickstart] for an extensible and robust
+example. It can be configured to handle the creation of all supporting resources
 (e.g. network, service accounts) or leave that to you. Slurm can be configured
 with partitions and nodesets as desired.
 
-> **NOTE:** It is recommended to use the
-> [slurm_cluster module](../terraform/slurm_cluster/README.md) in your own
-> [terraform project](./glossary.md#terraform-project). It may be useful to copy
-> and modify one of the provided examples.
+> **NOTE:** For deploying with
+> [Cluster toolkit](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/README.md),
+> use the command `gclusster deploy <your_config>.yaml`,
+> which manages the underlying infrastructure deployment
+> instead of the standard Terraform workflow involving
+> `terraform init`, `terraform validate`, and `terraform apply`.
+> Please refer to the [Create the cluster deployment folder][deployment].
 
 Alternatively, see
 [HPC Blueprints](https://cloud.google.com/hpc-toolkit/docs/setup/hpc-blueprint)
@@ -69,4 +60,5 @@ examples.
 
 <!-- Links -->
 
-[test-cluster]: ../terraform/slurm_cluster/examples/slurm_cluster/test_cluster/README.md
+[quickstart]: https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/README.md#quickstart
+[deployment]: https://cloud.google.com/cluster-toolkit/docs/quickstarts/slurm-cluster#create_the_cluster_deployment_folder

--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -21,6 +21,7 @@ taken into account. This guide will cover them and their recommended solutions.
 
 There are two deployment methods for cloud cluster management:
 
+- [Cluster Toolkit](https://cloud.google.com/cluster-toolkit/docs/overview)
 - [Terraform](#terraform)
 
 ## Terraform

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -83,7 +83,7 @@ out. Tickets can be submitted via
 ### How do I move data for a job?
 
 Data can be migrated to and from external sources using a workflow of dependent
-jobs. A [workflow submission script](../jobs/submit_workflow.py.py) and
+jobs. A [workflow submission script](https://github.com/GoogleCloudPlatform/slurm-gcp/blob/master/jobs/README.md#submit_workflowpy) and
 [helper jobs](../jobs/data_migrate/) are provided. See
 [README](../jobs/README.md) for more information.
 
@@ -115,25 +115,27 @@ jobs. A [workflow submission script](../jobs/submit_workflow.py.py) and
 Enhancement requests can be submitted to
 [SchedMD's Bugzilla](https://bugs.schedmd.com).
 
-### How do I use Terraform?
+### How do I modify Slurm config files with Terraform?
+To modify Slurm configuration files when deploying with Terraform on Google Cloud,
+the recommended approach is to use the Google Cloud Cluster Toolkit's Slurm module.
 
-Please see
-[Terraform documentation](https://learn.hashicorp.com/collections/terraform/gcp-get-started).
+Since release 6.8.6 all slurm-gcp terraform modules have been moved to
+[Cluster Toolkit](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/README.md)
 
-For the [Slurm terraform modules](../terraform/slurm_cluster/), please refer to
-their module API as documented in their README's. Additionally, please see the
-[Slurm terraform examples](../terraform/slurm_cluster/examples/) for sample
-usage.
+When using the Cluster Toolkit's Slurm Terraform module,
+you modify configuration files by providing custom configuration template files.
 
-### How do I modify Slurm config files?
+You specify the paths to your custom template files using the following input parameters:
 
-Presuming [slurm_cluster terraform module](../terraform/slurm_cluster/README.md)
-was used to deploy the cluster, see
-[input parameters](../terraform/slurm_cluster/README_TF.md#inputs):
+- slurm_conf_tpl: Path to your custom slurm.conf template.
+- cgroup_conf_tpl: Path to your custom cgroup.conf template.
+- slurmdbd_conf_tpl: Path to your custom slurmdbd.conf template (if using SlurmDBD).
 
-- slurm_conf_tpl
-- cgroup_conf_tpl
-- slurmdbd_conf_tpl
+Provide the local file paths for these parameters in your module configuration
+to use your custom configurations instead of the default ones.
+
+Please see [Terraform documentation](https://developer.hashicorp.com/terraform/tutorials/gcp-get-started)
+for general information on using Terraform on GCP.
 
 ### What are GCP preemptible VMs?
 
@@ -225,7 +227,7 @@ across all instances and allows easy user control with
 
 ### What Slurm image do I use for production?
 
-By default, the [slurm_cluster](../terraform/slurm_cluster/README.md) terraform
+By default, the slurm_cluster terraform
 module uses the latest Slurm image family (e.g.
 `slurm-gcp-6-9-hpc-rocky-linux-8`). As new Slurm image families are released,
 coenciding with periodic Slurm releases, the terraform module will be updated to

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -284,20 +284,18 @@ Simultaneous Multithreading (SMT) on/off.
 
 ### How do I automate custom cluster configurations?
 
-The [Slurm cluster module](../terraform/slurm_cluster/README.md) provide
-multiple variables (`controller_startup_scripts`, `compute_startup_scripts`,
-`partition_startup_scripts`) which allow you input a list of scripts which will
-be run on different sets of hosts at set-up time. The scripts are run
-synchronousely and a non-zero exit will fail the setup step of the instance.
-Generally, `controller_startup_scripts` will run only on the controller node;
-`compute_startup_scripts` will run on the log and all compute nodes, and
-`partition_startup_scripts` will on all compute nodes within that partition. See
-[Slurm cluster module variables](../terraform/slurm_cluster/variables.tf) for
-details.
+For automating custom configurations of your cluster, we recommend using the 
+[Cluster Toolkit](https://github.com/GoogleCloudPlatform/cluster-toolkit). 
+The Cluster Toolkit is an open-source project offered by Google Cloud designed
+to simplify the deployment of AI/ML and HPC environments on Google Cloud.
 
-If you want to install software, it is recommended to bake it into the image.
-Doing so will speed up the deployment of bursted compute nodes. See
-[customize image](./images.md#customize) for more information.
+For installing software and core configurations,
+it's highly recommended to bake them into a custom VM image beforehand
+to significantly speed up deployment, especially when scaling.
+
+See [customize images](./images.md#customize)
+for more information. More details on the Cluster Toolkit are available
+[here](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/docs/vm-images.md).
 
 ### How do I replace the controller?
 


### PR DESCRIPTION
1. In the 'Overview' section, Cluster Toolkit instead of GCP Marketplace.
2. Delete the 'GCP Marketplace' section and related to GCP Marketplace
3. 'Terraform'  and 'Quickstart Examples' sections edited