### PR TITLE
Doc updates batch

### DIFF
--- a/docs/federation.md
+++ b/docs/federation.md
@@ -26,7 +26,7 @@ This guide focuses on setting up a
 [Federation](#federation) is a superset of [multi-cluster](#multi-cluster). By
 setting up federation, you are also setting up multi-cluster.
 
-If using [slurm_cluster terraform module](../terraform/slurm_cluster/README.md),
+If using [Cluster Toolkit](https://github.com/GoogleCloudPlatform/cluster-toolkit),
 please refer to [multiple-slurmdbd](#multiple-slurmdbd) section.
 
 > **NOTE:** [slurmdbd](./glossary.md#slurmdbd) and the database (e.g. mariadb,
@@ -123,15 +123,17 @@ please refer to [multiple-slurmdbd](#multiple-slurmdbd) section.
    mysql, etc..).
 
    > **NOTE:**
-   > [slurm_cluster terraform module](../terraform/slurm_cluster/README.md)
-   > conflates the controller instance and the database instance.
+   > When the controller and database roles are combined onto a single instance
+   > (as completed by infrastructure provisioning),
+   > the [Cluster Toolkit](https://github.com/GoogleCloudPlatform/cluster-toolkit)
+   > is responsible for configuring both the controller and database software and services on that single instance.
 
 1. Deploy Slurm clusters by any chosen methods (e.g. cloud, hybrid, etc..).
 
-   > **WARNING:** If using the
-   > [slurm_cluster terraform module](../terraform/slurm_cluster/README.md), do
-   > not use the `cloudsql` input, as this does not work with a federation
-   > setup.
+   > **WARNING:** When setting up Slurm Federation,
+   > the [Cluster Toolkit](https://github.com/GoogleCloudPlatform/cluster-toolkit)
+   > cannot use the database provisioned/configured via the `cloudsql` input of the slurm_cluster Terraform module,
+   > because that database setup is incompatible with Federation requirements.
 
 1. Update each *slurm.conf* with:
 

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -26,7 +26,8 @@ This guide focuses on setting up a
 [Federation](#federation) is a superset of [multi-cluster](#multi-cluster). By
 setting up federation, you are also setting up multi-cluster.
 
-If using [Cluster Toolkit](https://github.com/GoogleCloudPlatform/cluster-toolkit),
+If using
+[slurm_cluster terraform module][slurm-gcp],
 please refer to [multiple-slurmdbd](#multiple-slurmdbd) section.
 
 > **NOTE:** [slurmdbd](./glossary.md#slurmdbd) and the database (e.g. mariadb,
@@ -132,7 +133,8 @@ please refer to [multiple-slurmdbd](#multiple-slurmdbd) section.
 
    > **WARNING:** When setting up Slurm Federation,
    > the [Cluster Toolkit](https://github.com/GoogleCloudPlatform/cluster-toolkit)
-   > cannot use the database provisioned/configured via the `cloudsql` input of the slurm_cluster Terraform module,
+   > cannot use the database provisioned/configured via the `cloudsql` input of the 
+   > [slurm_cluster terraform module][slurm-gcp],
    > because that database setup is incompatible with Federation requirements.
 
 1. Update each *slurm.conf* with:
@@ -153,3 +155,7 @@ please refer to [multiple-slurmdbd](#multiple-slurmdbd) section.
 ### Additional Requirements
 
 - All clusters must know where each [slurmdbd](./glossary.md#slurmdbd) is.
+
+<!-- Links -->
+
+[slurm-gcp]: https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/main/community/modules/internal/slurm-gcp

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -365,9 +365,15 @@ must have correct permissions and [GCP IAM roles](#iam-roles) to create, delete,
 and modify resources as defined in the [terraform project](#terraform-project).
 
 ## Terraform Project
-
-A terraform project is any directory that contains a set of terraform files
-(`*.tf`) which define providers, resources, and data.
+Since release 6.8.6 all slurm-gcp terraform modules have been moved to 
+[Cluster Toolkit](https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/main/community/modules/internal/slurm-gcp).
+These modules are used within a standard Terraform project, which is any directory that contains a set of Terraform files (`*.tf`) defining
+providers, resources, and data. The typical workflow for using these modules in your project involves the following commands:
+- `terraform init` to get the plugins
+- `terraform validate` to validate the configuration
+- `terraform plan -var-file=example.tfvars` to see the infrastructure plan
+- `terraform apply -var-file=example.tfvars` to apply the infrastructure build
+- `terraform destroy -var-file=example.tfvars` to destroy the built infrastructure
 
 ## Terraform Registry
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -366,7 +366,8 @@ and modify resources as defined in the [terraform project](#terraform-project).
 
 ## Terraform Project
 Since release 6.8.6 all slurm-gcp terraform modules have been moved to 
-[Cluster Toolkit](https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/main/community/modules/internal/slurm-gcp).
+[Cluster Toolkit](https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/main/community/modules/internal/slurm-gcp),
+where you can also find the [quickstart](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/README.md#quickstart) guide.
 These modules are used within a standard Terraform project, which is any directory that contains a set of Terraform files (`*.tf`) defining
 providers, resources, and data. The typical workflow for using these modules in your project involves the following commands:
 - `terraform init` to get the plugins

--- a/docs/htc.md
+++ b/docs/htc.md
@@ -40,7 +40,7 @@ for the Slurm HTC guide.
 To make slurm.conf changes in slurm-gcp in accordance with HTC recommendations,
 the currently supported method is to pass a slurm.conf template file into the
 controller module with input variables
-[\*\_tpl](../terraform/slurm_cluster/modules/slurm_controller_instance/README_TF.md#inputs).
+[\*\_tpl](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md).
 
 Currently, the terraform modules expose these template files which get rendered
 into the corresponding slurm configuration files:
@@ -84,7 +84,7 @@ See [setup.py](../scripts/setup.py#L147) for details.
 ## Example
 
 See
-[HTC example](../terraform/slurm_cluster/examples/slurm_cluster/cloud/htc/README.md).
+[HTC example](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/community/examples/htc-slurm.yaml).
 
 ## Hardware Recommendations
 
@@ -119,5 +119,9 @@ Example minimum system requirements ~ 100k jobs a day / 500 node
 OS level settings may need to be adjusted to optimize for HTC workloads or
 general operation. This can be achieved though building
 [custom images](./images.md#custom-image) or minimally though
-[startup scripts](../terraform/slurm_cluster/README_TF.md#inputs) for the
-compute instances.
+[startup scripts][startup-script] 
+for the compute instances.
+
+<!-- Links -->
+
+[startup-script]: https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/modules/scripts/startup-script/README.md

--- a/docs/hybrid.md
+++ b/docs/hybrid.md
@@ -89,6 +89,8 @@ their `slurm.conf`, by default.
 
 ## Terraform
 
+> **NOTE:** Since it only supports v5, some links are only meant to be used on the v5 branch.
+
 [Terraform](./glossary.md#terraform) is used to manage the cloud resources
 within your hybrid cluster. The
 [slurm_cluster](../terraform/slurm_cluster/README.md) module, when in hybrid
@@ -104,6 +106,8 @@ checkout out the [documentation](https://www.terraform.io/docs) and
 to get you familiar.
 
 ### Quickstart Examples
+
+> **NOTE:** Since it only supports v5, some links are only meant to be used on the v5 branch.
 
 See the [test cluster][test-cluster] example for an extensible and robust
 example. It can be configured to handle creation of all supporting resources
@@ -285,4 +289,4 @@ is critical.
 
 <!-- Links -->
 
-[test-cluster]: ../terraform/slurm_cluster/examples/slurm_cluster/test_cluster/README.md
+[test-cluster]: ./glossary.md#terraform-project


### PR DESCRIPTION
1. The Slurm-cluster Terraform module is replaced by Cluster toolkit, with additional states included.
2. The hyperlinks of *_tpl, HTC example and startup scripts have been moved to Cluster Toolkit.
3. The Terraform Project has been moved to Cluster Toolkit, and added quickstart link
4. The point is that it only supports v5, and test cluster links to examples.