### PR TITLE
Updated the NCCL and RxDM image URLs in a3-mega prologs.

### DIFF
--- a/tools/prologs-epilogs/receive-data-path-manager-mega
+++ b/tools/prologs-epilogs/receive-data-path-manager-mega
@@ -30,8 +30,8 @@ fi
 # ensure that dmabuf-import-helper is loaded
 modprobe import-helper
 
-NCCL_PLUGIN_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.8-1
-RXDM_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.14
+NCCL_PLUGIN_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.10
+RXDM_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.16
 RXDM_CONTAINER=receive-datapath-manager-"${SLURM_JOB_ID}"
 if [[ ${SLURM_SCRIPT_CONTEXT} == "prolog_slurmd" ]]; then
 	docker container list --filter "name=receive-datapath-manager-*" --quiet | xargs --no-run-if-empty docker container stop


### PR DESCRIPTION
Manually tested and verified.

NCCL image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.10
RxDM image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.16