### PR TITLE
Refactor NVIDIA dnf/apt repository solution

### DIFF
--- a/ansible/roles/nvidia_repository/defaults/main.yml
+++ b/ansible/roles/nvidia_repository/defaults/main.yml
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-dependencies:
-- role: nvidia_repository
-  when: enroot_install_optional_deps
+# distribution is defined per-distribution in ../vars/*.yml files
+nvidia_repo_url: https://developer.download.nvidia.com/compute/cuda/repos/{{ distribution }}/{{ ansible_architecture }}
+install_nvidia_repo: true

--- a/ansible/roles/nvidia_repository/tasks/main.yml
+++ b/ansible/roles/nvidia_repository/tasks/main.yml
@@ -13,14 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Include OS Family Dependent Tasks
-  include_tasks: '{{ item }}'
+- name: Include OS Family Dependent Vars
+  ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
-  - os/{{ ansible_distribution|lower }}-{{ ansible_distribution_version }}.yml
-  - os/{{ ansible_distribution|lower }}-{{ ansible_distribution_major_version }}.yml
-  - os/{{ ansible_distribution|lower }}.yml
-  - os/{{ ansible_os_family|lower }}-{{ ansible_distribution_version }}.yml
-  - os/{{ ansible_os_family|lower }}-{{ ansible_distribution_major_version }}.yml
-  - os/{{ ansible_os_family|lower }}.yml
+  - "{{ ansible_distribution | lower }}.yml"
+  - "{{ ansible_os_family | lower }}.yml"
+
   # this should only be disabled for images that already have an NVIDIA repository installed
+- name: Include OS Family Dependent Tasks
+  ansible.builtin.include_tasks: "{{ item }}"
+  with_first_found:
+  - os/{{ ansible_os_family | lower }}.yml
   when: install_nvidia_repo

--- a/ansible/roles/nvidia_repository/tasks/os/debian.yml
+++ b/ansible/roles/nvidia_repository/tasks/os/debian.yml
@@ -1,0 +1,63 @@
+---
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Download NVIDIA repository package
+  ansible.builtin.get_url:
+    url: "{{ nvidia_keyring_url }}"
+    dest: "{{ nvidia_keyring_filename }}"
+
+- name: Install NVIDIA repository package
+  ansible.builtin.apt:
+    deb: "{{ nvidia_keyring_filename }}"
+    state: present
+
+- name: Update apt cache to include new repository
+  ansible.builtin.apt:
+    update_cache: yes
+    cache_valid_time: 0
+
+- name: Delete NVIDIA repository files
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+  - /etc/apt/preferences.d/cuda-repository-pin-600
+  - "{{ nvidia_keyring_filename }}"
+
+- name: Lower NVIDIA repo priority below OS repos and block known broken package
+  ansible.builtin.copy:
+    dest: /etc/apt/preferences.d/nvidia-repository-lower-priority
+    owner: root
+    group: root
+    mode: '0644'
+    content: |
+      Package: nsight-compute
+      Pin: origin *ubuntu.com*
+      Pin-Priority: -1
+
+      Package: nsight-systems
+      Pin: origin *ubuntu.com*
+      Pin-Priority: -1
+
+      Package: *
+      Pin: release l=NVIDIA CUDA
+      Pin-Priority: 400
+
+      # The 1.17.7 release contains bugs that break enroot functionality on Slurm clusters
+      # e.g., https://github.com/NVIDIA/enroot/issues/232
+      # This pinning makes the version uninstallable by default
+      Package: nvidia-container-toolkit nvidia-container-toolkit-base libnvidia-container-tools libnvidia-container1
+      Pin: version 1.17.7-1
+      Pin-Priority: 100

--- a/ansible/roles/nvidia_repository/tasks/os/redhat.yml
+++ b/ansible/roles/nvidia_repository/tasks/os/redhat.yml
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-dependencies:
-- role: nvidia_repository
-  when: enroot_install_optional_deps
+- name: Add NVIDIA repository
+  ansible.builtin.command: dnf config-manager --add-repo {{ nvidia_repo_url }}/cuda-{{ distribution }}.repo
+  creates: /etc/yum.repos.d/cuda-{{ distribution }}.repo

--- a/ansible/roles/nvidia_repository/vars/debian.yml
+++ b/ansible/roles/nvidia_repository/vars/debian.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apt_keyring: /etc/apt/keyrings
-nvidia_gpg_key_url: https://nvidia.github.io/libnvidia-container/gpgkey
-nvidia_repo_url_deb: https://nvidia.github.io/libnvidia-container/stable/deb
-nvidia_gpg_key_deb: "{{ apt_keyring }}/nvidia-container-toolkit-keyring.asc"
-nvidia_repo_file_rpm: https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo
-install_nvidia_repo: true
+distribution: "{{ ansible_distribution | lower }}{{ ansible_distribution_major_version }}"
+nvidia_keyring_url: "{{ nvidia_repo_url }}/cuda-keyring_1.1-1_all.deb"
+nvidia_keyring_filename: /tmp/{{ nvidia_keyring_url | basename }}

--- a/ansible/roles/nvidia_repository/vars/redhat.yml
+++ b/ansible/roles/nvidia_repository/vars/redhat.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,20 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Check and create keyring folder
-  ansible.builtin.file:
-    path: "{{ apt_keyring }}"
-    state: directory
-    mode: '0755'
-
-- name: Collect Nvidia Container Repo GPG Key
-  ansible.builtin.get_url:
-    url: "{{ nvidia_gpg_key_url }}"
-    dest: "{{ nvidia_gpg_key_deb }}"
-    mode: '0644'
-    force: true
-
-- name: Add Nvidia Container Repo
-  ansible.builtin.apt_repository:
-    repo: "deb [arch=amd64 signed-by={{ nvidia_gpg_key_deb }}] {{ nvidia_repo_url_deb }}/$(ARCH) /"
-    filename: nvidia-container-toolkit
+distribution: rhel{{ansible_distribution_major_version}}

--- a/ansible/roles/nvidia_repository/vars/ubuntu.yml
+++ b/ansible/roles/nvidia_repository/vars/ubuntu.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Add Nvidia Container Repo
-  ansible.builtin.get_url:
-    url: '{{ nvidia_repo_file_rpm }}'
-    dest: /etc/yum.repos.d/nvidia-container-toolkit.repo
+distribution: "{{ ansible_distribution | lower }}{{ ansible_distribution_version | replace('.','') }}"
+nvidia_keyring_url: "{{ nvidia_repo_url }}/cuda-keyring_1.1-1_all.deb"
+nvidia_keyring_filename: /tmp/{{ nvidia_keyring_url | basename }}


### PR DESCRIPTION
The existing solution for installing `libnvidia-container-tools` packages (for enroot container runtime) was aimed was aimed purely at the problem of installing that packages. This package is also released under a broader repository for CUDA which includes `libnvidia-container-tools`, the CUDA Toolkit itself, and packaged versions of NVIDIA drivers.

This PR changes no functionality but is a step toward installing CUDA Toolkit and NVIDIA drivers via OS packaging mechanisms rather than the `.run` script.

It has been manually tested on Ubuntu 22.04 and the Rocky Linux 8 HPC VM Images.