### PR TITLE
Disable lustre installation for ubuntu 24.04

### DIFF
--- a/ansible/roles/lustre/vars/ubuntu-24.04.yml
+++ b/ansible/roles/lustre/vars/ubuntu-24.04.yml
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-lustre_repo_url: https://downloads.whamcloud.com/public/lustre/latest-release/ubuntu2404/client
+lustre_repo_url: https://downloads.whamcloud.com/public/lustre/latest-release/ubuntu2204/client
 
 lustre_packages:
 - lustre-client-modules
 - lustre-client-utils
+
+# disable lustre install because it's not compatible right now
+lustre_install: false


### PR DESCRIPTION
No repo support for ubuntu 24.04, going to disable the `lustre_install` variable in a similar manner for other unsupported OS  distributions (debian 11/12)