### PR TITLE
Fix & update A3-Mega RxDM prolog

### DIFF
--- a/tools/prologs-epilogs/receive-data-path-manager-mega
+++ b/tools/prologs-epilogs/receive-data-path-manager-mega
@@ -30,8 +30,8 @@ fi
 # ensure that dmabuf-import-helper is loaded
 modprobe import-helper
 
-NCCL_PLUGIN_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.8-1
-RXDM_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.14
+NCCL_PLUGIN_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.10
+RXDM_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.16
 RXDM_CONTAINER=receive-datapath-manager-"${SLURM_JOB_ID}"
 if [[ ${SLURM_SCRIPT_CONTEXT} == "prolog_slurmd" ]]; then
 	docker container list --filter "name=receive-datapath-manager-*" --quiet | xargs --no-run-if-empty docker container stop
@@ -53,10 +53,6 @@ if [[ ${SLURM_SCRIPT_CONTEXT} == "prolog_slurmd" ]]; then
         # above, and assumes interface names of eth{0..8}.
 	if ( (grep -q "ID=debian" /etc/os-release && lsb_release -rs | grep -q "12") || (grep -q "ID=ubuntu" /etc/os-release) ); then
 		cat >>/var/lib/tcpxo/lib64/nccl-env-profile.sh <<-EOF
-			export NCCL_FASTRAK_LLCM_DEVICE_DIRECTORY=/dev/aperture_devices
-			export LD_LIBRARY_PATH=/var/lib/tcpxo/lib64:\${LD_LIBRARY_PATH}
-		EOF
-		cat >>/var/lib/tcpxo/lib64/nccl-env-profile-ll128.sh <<-EOF
 			export NCCL_FASTRAK_LLCM_DEVICE_DIRECTORY=/dev/aperture_devices
 			export LD_LIBRARY_PATH=/var/lib/tcpxo/lib64:\${LD_LIBRARY_PATH}
 		EOF


### PR DESCRIPTION
Fixes Ubuntu NCCL_FASTRAK_LLCM_DEVICE_DIRECTORY directory setting for TCPXO. Also updates to latest RxDM / NCCL plugin. 

Supercedes https://github.com/GoogleCloudPlatform/slurm-gcp/pull/271

NCCL image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.10
RxDM image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.16

nccl-env-profile-ll128.sh is now a symlink to nccl-env-profile.sh, as LL128 PROTO is now default.

Has been manually tested. 