### PR TITLE
update cloud ops agent

### DIFF
--- a/ansible/roles/cloudagents/templates/legacy_agent_py_script_log.conf.j2
+++ b/ansible/roles/cloudagents/templates/legacy_agent_py_script_log.conf.j2
@@ -1,7 +1,7 @@
 <source>
   @type tail
   format /^(?<time>\S+ \S+) (?<message>(?<severity>(CRITICAL|ERROR|WARNING|INFO|DEBUG))(\(\S+\))?:.*)$/
-  path /var/log/slurm/resume.log,/var/log/slurm/suspend.log,/var/log/slurm/slurmsync.log,/slurm/scripts/setup.log
+  path /var/log/slurm/resume.log,/var/log/slurm/suspend.log,/var/log/slurm/slurmsync.log,/var/log/slurm/setup.log
   pos_file /var/lib/google-fluentd/pos/slurm_py_script.pos
   read_from_head true
   tag slurm

--- a/ansible/roles/cloudagents/templates/ops_agent.yaml.j2
+++ b/ansible/roles/cloudagents/templates/ops_agent.yaml.j2
@@ -52,7 +52,12 @@ logging:
     setup:
       type: files
       include_paths:
-      - /slurm/scripts/setup.log
+      - /var/log/slurm/setup.log
+      record_log_file_path: true
+    chs_health_check:
+      type: files
+      include_paths:
+      - /var/log/slurm/chs_health_check.log
       record_log_file_path: true
   processors:
     parse_slurmlog:
@@ -79,5 +84,6 @@ logging:
         - slurm_suspend
         - slurm_sync
         - setup
+        - chs_health_check
         processors:
         - parse_slurmlog2

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -56,7 +56,7 @@ $ scontrol setdebugflags +power
 ## Instance startup-script failed
 
 Upon startup-script failure, all users should be notified via `wall` and `motd`.
-Check `/slurm/scripts/setup.log` for details about the failure.
+Check `/var/log/slurm/setup.log` for details about the failure.
 
 ## Quota limits
 


### PR DESCRIPTION
The path to the setup.log file in cloud ops agent is outdated, and needs to be changed to /var/log/slurm/setup.log.
Cloud ops agent needs to be updated to include /var/log/slurm/chs_health_check.log