### PR TITLE
Ignore errors on failure when applying Slurm patches to image build

### DIFF
--- a/ansible/roles/slurm/tasks/install.yml
+++ b/ansible/roles/slurm/tasks/install.yml
@@ -48,10 +48,10 @@
   ansible.posix.patch:
     src: ../files/patches/{{ item }}
     basedir: '{{slurm_paths.src}}'
-    remote_src: false
     strip: 1
   loop: "{{ slurm_patch_files }}"
-  when: slurm_patch_files != [] and handle_services
+  ignore_errors: true
+  when: slurm_patch_files != []
 
 - name: Configure
   shell:


### PR DESCRIPTION
*Removal of `remote_src:false` because this is default behavior and thus not needed.*

During image building the slurm ansible role runs twice (if a role is given as a dependency with different input values it will run the role again). As such since the patch is already been applied the ansible.posix.patch module considers it a failure:

```
    slurm-gcp.googlecompute.image: TASK [slurm : Apply Slurm patches] *********************************************
    slurm-gcp.googlecompute.image: An exception occurred during task execution. To see the full traceback, use -vvv. The error was: 1 out of 1 hunk ignored
    slurm-gcp.googlecompute.image: failed: [default] (item=task_prolog_epilog.patch) => changed=false
    slurm-gcp.googlecompute.image:   ansible_loop_var: item
    slurm-gcp.googlecompute.image:   item: task_prolog_epilog.patch
    slurm-gcp.googlecompute.image:   msg: |-
    slurm-gcp.googlecompute.image:     Reversed (or previously applied) patch detected!  Skipping patch.
    slurm-gcp.googlecompute.image:     4 out of 4 hunks ignored
    slurm-gcp.googlecompute.image:     1 out of 1 hunk FAILED
    slurm-gcp.googlecompute.image:     Reversed (or previously applied) patch detected!  Skipping patch.
    slurm-gcp.googlecompute.image:     1 out of 1 hunk ignored
    slurm-gcp.googlecompute.image:     1 out of 1 hunk FAILED
    slurm-gcp.googlecompute.image:     1 out of 1 hunk FAILED
    slurm-gcp.googlecompute.image:     Reversed (or previously applied) patch detected!  Skipping patch.
    slurm-gcp.googlecompute.image:     1 out of 1 hunk ignored
    slurm-gcp.googlecompute.image:     Reversed (or previously applied) patch detected!  Skipping patch.
    slurm-gcp.googlecompute.image:     1 out of 1 hunk ignored
    slurm-gcp.googlecompute.image:     Reversed (or previously applied) patch detected!  Skipping patch.
    slurm-gcp.googlecompute.image:     1 out of 1 hunk ignored
    slurm-gcp.googlecompute.image:
```
We have some options for this:
a) Don't use `patch` module, use `cmd` module which has more error handling options and we can use `stderr` to ignore errors that match this keyword.
b) Restructure the playbook so this dependency is not necessary in the first place (technically this leads to the Slurm installation tasks run twice as-is).
c) Consider errors for patch non-consequential as a whole.

It's important to note that the errors are still logged, and so if there was some other reason the patch could not be applied (wrong format) then the logs would indicate as such and in addition they would be cause the subsequent `Make` task to fail.

