### PR TITLE
adding NVIDIA IMEX epilog and prolog script to tools/prolog-epilogs

### DIFF
--- a/tools/prologs-epilogs/imex_epilog
+++ b/tools/prologs-epilogs/imex_epilog
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Slurm Epilog for NVIDIA Imex
+
+set -ex
+
+if ! systemctl list-unit-files --all | grep -Fq "nvidia-imex.service"; then
+    exit 0
+fi
+
+# Clean the config file in case the service gets started by accident
+> /etc/nvidia-imex/nodes_config.cfg
+
+NVIDIA_IMEX_STOP_TIMEOUT=30
+
+# clean up connection
+set +e
+
+timeout $NVIDIA_IMEX_STOP_TIMEOUT systemctl stop nvidia-imex
+
+pkill -9 nvidia-imex
+set -e

--- a/tools/prologs-epilogs/imex_prolog
+++ b/tools/prologs-epilogs/imex_prolog
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Slurm Prolog for NVIDIA Imex
+
+if ! systemctl list-unit-files --all | grep -Fq "nvidia-imex.service"; then
+    exit 0
+fi
+
+activate_imex() {
+    set -ex
+
+    # Clean the config file in case the service gets started by accident
+    > /etc/nvidia-imex/nodes_config.cfg
+
+    NVIDIA_IMEX_START_TIMEOUT=80
+    IMEX_CONN_WAIT_TIMEOUT=70
+    IMEX_SHUTDOWN_WAIT=60
+    NVIDIA_IMEX_STOP_TIMEOUT=15
+    DOMAIN_READY_TIMEOUT=15
+    IMEX_SERVER_PORT=1101
+    IMEX_CMD_PORT=1102
+    # clean up prev connection
+    set +e
+    timeout $NVIDIA_IMEX_STOP_TIMEOUT systemctl stop nvidia-imex
+    pkill -9 nvidia-imex
+    set -e
+
+    # update peer list
+    scontrol -a show node "${SLURM_NODELIST}" -o | sed 's/^.* NodeAddr=\([^ ]*\).*/\1/' > /etc/nvidia-imex/nodes_config.cfg
+
+    # rotate server port to prevent race condition
+    sed -i "s/SERVER_PORT.*/SERVER_PORT=${IMEX_SERVER_PORT}/" /etc/nvidia-imex/config.cfg
+
+    # enable imex-ctl on all nodes so you can query imex status with: nvidia-imex-ctl -a -q
+    sed -i "s/IMEX_CMD_PORT.*/IMEX_CMD_PORT=${IMEX_CMD_PORT}/" /etc/nvidia-imex/config.cfg
+    sed -i "s/IMEX_CMD_ENABLED.*/IMEX_CMD_ENABLED=1/" /etc/nvidia-imex/config.cfg
+
+    # set timeouts for start
+    sed -i "s/IMEX_CONN_WAIT_TIMEOUT.*/IMEX_CONN_WAIT_TIMEOUT=${IMEX_CONN_WAIT_TIMEOUT}/" /etc/nvidia-imex/config.cfg
+
+    sleep ${IMEX_SHUTDOWN_WAIT}
+    netstat -na | grep tcp | grep ":${IMEX_SERVER_PORT}" || true
+    netstat -na | grep tcp | grep ":${IMEX_CMD_PORT}" || true
+
+    timeout $NVIDIA_IMEX_START_TIMEOUT systemctl start nvidia-imex
+
+    sleep ${DOMAIN_READY_TIMEOUT}
+}
+
+activate_imex >> "/var/log/slurm/imex_prolog_${SLURM_JOB_ID}.log" 2>&1


### PR DESCRIPTION
Moved the epilog and prolog script from the A4X SLURM blueprint in cluster-toolkit repo to the slurm-gcp repo.
Corresponding PR in the cluster-toolkit repo: https://github.com/GoogleCloudPlatform/cluster-toolkit/pull/4733