### PR TITLE
Add install_munge control flag

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -57,6 +57,7 @@
     install_ompi: true
     install_lustre: true
     install_managed_lustre: false
+    install_munge: true
     slurm_patch_files: []
     install_gcsfuse: true
     install_gcsfuse_spank: false
@@ -159,7 +160,9 @@
     - install_pmix
   - nfs
   - cgroups
-  - munge
+  - role: munge
+    when:
+    - install_munge
   - mariadb
   - libjwt
   - lmod


### PR DESCRIPTION
Munge was set to be installed by default. Due to the recent munge vulnerability, we should let the user decide whether they want to install munge or not. The default value of install_munge is still set to be true.