### PR TITLE
Workaround for missing Debian 12 kernel headers (6.1.0-43)

### DIFF
--- a/ansible/roles/kernel/tasks/os/debian.yml
+++ b/ansible/roles/kernel/tasks/os/debian.yml
@@ -42,54 +42,40 @@
 - name: Install running kernel headers
   ansible.builtin.apt:
     name: "linux-headers-{{ ansible_kernel }}"
-  ignore_errors: yes
-  when: 
-    - not tpu_docker_image
-    - ansible_kernel != "6.1.0-43-cloud-amd64" # Skip if we are using the manual workaround
-
-- name: Download specific kernel headers and common dependency
-  ansible.builtin.get_url:
-    url: "{{ item.url }}"
-    dest: "{{ item.dest }}"
-    checksum: "sha1:{{ item.checksum }}"
-  loop:
-    - { 
-        url: "https://snapshot.debian.org/archive/debian/20260219T203930Z/pool/main/l/linux/linux-headers-6.1.0-43-common_6.1.162-1_all.deb", 
-        dest: "/tmp/linux-headers-6.1.0-43-common.deb",
-        checksum: "566a4d70d4be67cda86f36fb8a10efe2fcce9138"
-      }
-    - { 
-        url: "https://snapshot.debian.org/archive/debian/20260219T203930Z/pool/main/l/linux/linux-headers-6.1.0-43-cloud-amd64_6.1.162-1_amd64.deb", 
-        dest: "/tmp/linux-headers-6.1.0-43-cloud-amd64.deb",
-        checksum: "07d78100f45443669eebac0875b068b1bb506e5f"
-      }
   when:
-    - ansible_distribution == "Debian"
-    - ansible_kernel == "6.1.0-43-cloud-amd64"
-    - not tpu_docker_image
+  - not tpu_docker_image
+  - ansible_kernel != "6.1.0-43-cloud-amd64" # Skip if we are using the manual workaround
 
-- name: Install downloaded kernel headers
-  ansible.builtin.apt:
-    deb: "{{ item.dest }}"
-  loop:
-    - { dest: "/tmp/linux-headers-6.1.0-43-common.deb" }
-    - { dest: "/tmp/linux-headers-6.1.0-43-cloud-amd64.deb" }
-  when:
-    - ansible_distribution == "Debian"
-    - ansible_kernel == "6.1.0-43-cloud-amd64"
-    - not tpu_docker_image
-
-- name: Clean up downloaded debs
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: absent
-  loop:
-  - "/tmp/linux-headers-6.1.0-43-common.deb"
-  - "/tmp/linux-headers-6.1.0-43-cloud-amd64.deb"
+- name: Workaround for missing Debian 12 kernel headers (6.1.0-43)
   when:
   - ansible_distribution == "Debian"
   - ansible_kernel == "6.1.0-43-cloud-amd64"
   - not tpu_docker_image
+  block:
+  - name: Download specific kernel headers and common dependency
+    ansible.builtin.get_url:
+      url: "{{ item.url }}"
+      dest: "{{ item.dest }}"
+      checksum: "sha1:{{ item.checksum }}"
+      mode: '0644' # Added explicit mode
+    loop:
+    - {url: "https://snapshot.debian.org/archive/debian/20260219T203930Z/pool/main/l/linux/linux-headers-6.1.0-43-common_6.1.162-1_all.deb", dest: "/tmp/linux-headers-6.1.0-43-common.deb", checksum: "566a4d70d4be67cda86f36fb8a10efe2fcce9138"}
+    - {url: "https://snapshot.debian.org/archive/debian/20260219T203930Z/pool/main/l/linux/linux-headers-6.1.0-43-cloud-amd64_6.1.162-1_amd64.deb", dest: "/tmp/linux-headers-6.1.0-43-cloud-amd64.deb", checksum: "07d78100f45443669eebac0875b068b1bb506e5f",}
+
+  - name: Install downloaded kernel headers
+    ansible.builtin.apt:
+      deb: "{{ item }}"
+    loop:
+    - "/tmp/linux-headers-6.1.0-43-common.deb"
+    - "/tmp/linux-headers-6.1.0-43-cloud-amd64.deb"
+
+  - name: Clean up downloaded debs
+    ansible.builtin.file:
+      path: "{{ item }}"
+      state: absent
+    loop:
+    - "/tmp/linux-headers-6.1.0-43-common.deb"
+    - "/tmp/linux-headers-6.1.0-43-cloud-amd64.deb"
 
 - name: Install generic kernel headers
   ansible.builtin.apt:

--- a/ansible/roles/kernel/tasks/os/debian.yml
+++ b/ansible/roles/kernel/tasks/os/debian.yml
@@ -43,30 +43,41 @@
   ansible.builtin.apt:
     name: "linux-headers-{{ ansible_kernel }}"
   ignore_errors: yes
-  when: not tpu_docker_image
+  when: 
+    - not tpu_docker_image
+    - ansible_kernel != "6.1.0-43-cloud-amd64" # Skip if we are using the manual workaround
 
 - name: Download specific kernel headers and common dependency
   ansible.builtin.get_url:
     url: "{{ item.url }}"
     dest: "{{ item.dest }}"
+    checksum: "sha1:{{ item.checksum }}"
   loop:
-  - { url: "https://ftp.debian.org/debian/pool/main/l/linux/linux-headers-6.1.0-43-common_6.1.162-1_all.deb", dest: "/tmp/linux-headers-6.1.0-43-common.deb" }
-  - { url: "https://ftp.debian.org/debian/pool/main/l/linux/linux-headers-6.1.0-43-cloud-amd64_6.1.162-1_amd64.deb", dest: "/tmp/linux-headers-6.1.0-43-cloud-amd64.deb" }
+    - { 
+        url: "https://snapshot.debian.org/archive/debian/20260219T203930Z/pool/main/l/linux/linux-headers-6.1.0-43-common_6.1.162-1_all.deb", 
+        dest: "/tmp/linux-headers-6.1.0-43-common.deb",
+        checksum: "566a4d70d4be67cda86f36fb8a10efe2fcce9138"
+      }
+    - { 
+        url: "https://snapshot.debian.org/archive/debian/20260219T203930Z/pool/main/l/linux/linux-headers-6.1.0-43-cloud-amd64_6.1.162-1_amd64.deb", 
+        dest: "/tmp/linux-headers-6.1.0-43-cloud-amd64.deb",
+        checksum: "07d78100f45443669eebac0875b068b1bb506e5f"
+      }
   when:
-  - ansible_distribution == "Debian"
-  - ansible_kernel == "6.1.0-43-cloud-amd64"
-  - not tpu_docker_image
+    - ansible_distribution == "Debian"
+    - ansible_kernel == "6.1.0-43-cloud-amd64"
+    - not tpu_docker_image
 
-- name: Install specific kernel headers
+- name: Install downloaded kernel headers
   ansible.builtin.apt:
-    deb: "{{ item }}"
+    deb: "{{ item.dest }}"
   loop:
-  - "/tmp/linux-headers-6.1.0-43-common.deb"
-  - "/tmp/linux-headers-6.1.0-43-cloud-amd64.deb"
+    - { dest: "/tmp/linux-headers-6.1.0-43-common.deb" }
+    - { dest: "/tmp/linux-headers-6.1.0-43-cloud-amd64.deb" }
   when:
-  - ansible_distribution == "Debian"
-  - ansible_kernel == "6.1.0-43-cloud-amd64"
-  - not tpu_docker_image
+    - ansible_distribution == "Debian"
+    - ansible_kernel == "6.1.0-43-cloud-amd64"
+    - not tpu_docker_image
 
 - name: Clean up downloaded debs
   ansible.builtin.file:

--- a/ansible/roles/kernel/tasks/os/debian.yml
+++ b/ansible/roles/kernel/tasks/os/debian.yml
@@ -54,28 +54,31 @@
   block:
   - name: Download specific kernel headers and common dependency
     ansible.builtin.get_url:
-      url: "{{ item.url }}"
-      dest: "{{ item.dest }}"
-      checksum: "sha1:{{ item.checksum }}"
+      url: "{{ deb_info.url }}"
+      dest: "{{ deb_info.dest }}"
+      checksum: "sha1:{{ deb_info.checksum }}"
       mode: '0644' # Added explicit mode
     loop:
     - {url: "https://snapshot.debian.org/archive/debian/20260219T203930Z/pool/main/l/linux/linux-headers-6.1.0-43-common_6.1.162-1_all.deb", dest: "/tmp/linux-headers-6.1.0-43-common.deb", checksum: "566a4d70d4be67cda86f36fb8a10efe2fcce9138"}
-    - {url: "https://snapshot.debian.org/archive/debian/20260219T203930Z/pool/main/l/linux/linux-headers-6.1.0-43-cloud-amd64_6.1.162-1_amd64.deb", dest: "/tmp/linux-headers-6.1.0-43-cloud-amd64.deb", checksum: "07d78100f45443669eebac0875b068b1bb506e5f",}
+    - {url: "https://snapshot.debian.org/archive/debian/20260219T203930Z/pool/main/l/linux/linux-headers-6.1.0-43-cloud-amd64_6.1.162-1_amd64.deb", dest: "/tmp/linux-headers-6.1.0-43-cloud-amd64.deb", checksum: "07d78100f45443669eebac0875b068b1bb506e5f"}
+    loop_control: {loop_var: deb_info}
 
   - name: Install downloaded kernel headers
     ansible.builtin.apt:
-      deb: "{{ item }}"
+      deb: "{{ deb_path }}"
     loop:
     - "/tmp/linux-headers-6.1.0-43-common.deb"
     - "/tmp/linux-headers-6.1.0-43-cloud-amd64.deb"
+    loop_control: {loop_var: deb_path}
 
   - name: Clean up downloaded debs
     ansible.builtin.file:
-      path: "{{ item }}"
+      path: "{{ deb_path }}"
       state: absent
     loop:
     - "/tmp/linux-headers-6.1.0-43-common.deb"
     - "/tmp/linux-headers-6.1.0-43-cloud-amd64.deb"
+    loop_control: {loop_var: deb_path}
 
 - name: Install generic kernel headers
   ansible.builtin.apt:

--- a/ansible/roles/kernel/tasks/os/debian.yml
+++ b/ansible/roles/kernel/tasks/os/debian.yml
@@ -34,12 +34,51 @@
     setup:
   when: reboot
 
-- name: Install running kernel headers and metapackage to ensure upgrades
+- name: Install kernel headers metapackage
   ansible.builtin.apt:
-    name:
-    - linux-headers-{{ ansible_kernel }}
-    - "{{ kernel_headers_package }}"
+    name: "{{ kernel_headers_package }}"
   when: not tpu_docker_image
+
+- name: Install running kernel headers
+  ansible.builtin.apt:
+    name: "linux-headers-{{ ansible_kernel }}"
+  ignore_errors: yes
+  when: not tpu_docker_image
+
+- name: Download specific kernel headers and common dependency
+  ansible.builtin.get_url:
+    url: "{{ item.url }}"
+    dest: "{{ item.dest }}"
+  loop:
+  - { url: "https://ftp.debian.org/debian/pool/main/l/linux/linux-headers-6.1.0-43-common_6.1.162-1_all.deb", dest: "/tmp/linux-headers-6.1.0-43-common.deb" }
+  - { url: "https://ftp.debian.org/debian/pool/main/l/linux/linux-headers-6.1.0-43-cloud-amd64_6.1.162-1_amd64.deb", dest: "/tmp/linux-headers-6.1.0-43-cloud-amd64.deb" }
+  when:
+  - ansible_distribution == "Debian"
+  - ansible_kernel == "6.1.0-43-cloud-amd64"
+  - not tpu_docker_image
+
+- name: Install specific kernel headers
+  ansible.builtin.apt:
+    deb: "{{ item }}"
+  loop:
+  - "/tmp/linux-headers-6.1.0-43-common.deb"
+  - "/tmp/linux-headers-6.1.0-43-cloud-amd64.deb"
+  when:
+  - ansible_distribution == "Debian"
+  - ansible_kernel == "6.1.0-43-cloud-amd64"
+  - not tpu_docker_image
+
+- name: Clean up downloaded debs
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+  - "/tmp/linux-headers-6.1.0-43-common.deb"
+  - "/tmp/linux-headers-6.1.0-43-cloud-amd64.deb"
+  when:
+  - ansible_distribution == "Debian"
+  - ansible_kernel == "6.1.0-43-cloud-amd64"
+  - not tpu_docker_image
 
 - name: Install generic kernel headers
   ansible.builtin.apt:


### PR DESCRIPTION
### Summary:
Building Debian 12 images with Packer/Ansible currently fails because the `linux-headers-6.1.0-43-cloud-amd64` package is no longer available in the standard Debian repositories. This kernel version was deprecated by the Debian community when newer versions were published.

Since the debian 12 base os image used for slurm-gcp (published in the "debian-cloud" project) still use the 6.1.0-43 kernel, we cannot install the corresponding headers via the standard apt module. Upgrading the kernel immediately is not feasible as it could cause regressions with CUDA installations or other untested components.

The package is still available in snapshot.debian.org, so we can use this repo for installing the linux-headers package as a workaround until new debian 12 images are published internally.

### Workaround
This PR implements a workaround by pinning and downloading the specific kernel headers from the snapshot.debian.org archive. This allows the build to proceed with the existing kernel until updated base images (with 6.1.0-44+) are available internally.

### Changes

- **Skip Primary Installation:** Modified the "Install running kernel headers" task to skip when the running kernel is exactly 6.1.0-43-cloud-amd64.
- **Pinned Downloads:** Added a task to download linux-headers-6.1.0-43-common and linux-headers-6.1.0-43-cloud-amd64 from snapshot.debian.org.
- **Security Checksums:** Integrated SHA1 checksum verification for both downloaded .deb files to ensure integrity and security.
- **Manual Installation:** Added a task to install the downloaded local .deb files using the ansible.builtin.apt module.
- **Environment Cleanup:** Included a cleanup task to remove the temporary .deb files from /tmp/ after a successful installation.

### Testing
Verified the workaround by creating a Debian 12 image with Slurm 25.11.04. Basic smoke tests were performed on the resulting image to confirm that Slurm functionality is intact and the kernel headers were correctly utilized during the build process.