### PR TITLE
fix(ansible/lmod): Disable conflicting legacy profile scripts to prevent MODULEPATH corruption

### DIFF
--- a/ansible/roles/lmod/tasks/main.yml
+++ b/ansible/roles/lmod/tasks/main.yml
@@ -57,6 +57,16 @@
     cmd: make install > /dev/null
     chdir: '{{lmod_paths.src}}'
 
+- name: Disable conflicting default module/scl profile scripts
+  file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /etc/profile.d/modules.sh
+    - /etc/profile.d/modules.csh
+    - /etc/profile.d/scl-init.sh
+    - /etc/profile.d/scl.sh
+
 - name: Symbolic Link
   file:
     src: '{{item.src}}'

--- a/ansible/roles/lmod/tasks/main.yml
+++ b/ansible/roles/lmod/tasks/main.yml
@@ -58,14 +58,15 @@
     chdir: '{{lmod_paths.src}}'
 
 - name: Disable conflicting default module/scl profile scripts
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: absent
   loop:
-    - /etc/profile.d/modules.sh
-    - /etc/profile.d/modules.csh
-    - /etc/profile.d/scl-init.sh
-    - /etc/profile.d/scl.sh
+  - /etc/profile.d/modules.sh
+  - /etc/profile.d/modules.csh
+  - /etc/profile.d/scl-init.sh
+  - /etc/profile.d/scl.sh
+  when: ansible_os_family == 'RedHat'
 
 - name: Symbolic Link
   file:


### PR DESCRIPTION
## Summary
This PR resolves a critical environment initialization conflict on RedHat-based (Rocky Linux / CentOS) login and compute nodes by disabling conflicting legacy startup profile scripts during Lmod deployment.

## The Problem
When deploying clusters using Lmod as the primary module manager, legacy environment module and Software Collections (SCL) packages on RHEL/Rocky Linux install default startup scripts in `/etc/profile.d/` (specifically `modules.sh`, `modules.csh`, `scl-init.sh`, and `scl.sh`). 

During user login, both the legacy Tcl-based scripts and Lmod's modern `z00_lmod.sh` are executed. Because of the order of execution:
1. The legacy scripts overwrite and distort the `MODULEPATH` environment variable.
2. This corrupts custom prepend priorities (e.g., user prepends via `module use` are pushed back).
3. Duplicated search paths are introduced into `MODULEPATH`, degrading environment stability and making custom application modules invisible or inaccessible.

## The Solution
This patch introduces an idempotent cleanup step within the `lmod` Ansible role tasks (`ansible/roles/lmod/tasks/main.yml`):
* It utilizes the standard, back-compatible `ansible.builtin.file` module with `state: absent` to ensure the four clashing legacy profile scripts are removed from `/etc/profile.d/`.
* This cleanly disables the conflicting startup shell hooks while leaving the base system packages entirely intact.

## OS Portability & Idempotency Safeties
* **Idempotent**: If the files have already been removed (or are named differently), the task completes cleanly with a success status (`changed: false`) without throwing any errors or warnings.
* **Portable**: On Debian-based systems (Ubuntu), where these files do not exist by default, the tasks are cleanly evaluated and skipped without side effects.
* **Non-Destructive**: For symbolic links (e.g. `/etc/profile.d/modules.sh` pointing to alternatives), it removes only the symlink itself, avoiding deletion of the underlying target binaries.

## Verification & Testing
This fix has been verified on a live Rocky Linux 9 Slurm cluster:
1. Audited `/etc/profile.d/` to confirm the legacy scripts were successfully deleted.
2. Confirmed `Lmod` initialized flawlessly upon login with zero command-line warnings or parser errors.
3. Verified `MODULEPATH` evaluates to the clean, expected defaults:
   `/etc/modulefiles:/usr/share/modulefiles:/opt/apps/modulefiles`
4. Verified that prepending custom paths (e.g., `module use /tmp/hello`) correctly maintains **Index 0** priority across login subshells (`bash -l`) without duplicates or priority shifts.
