### PR TITLE
Add support for Building HPC-RL9 slurm images 

### DIFF
--- a/ansible/group_vars/os_centos.yml
+++ b/ansible/group_vars/os_centos.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) SchedMD LLC.
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,32 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-slurm_packages:
-- cifs-utils
-- gtk2-devel
-- hdf5-devel
-- http-parser-devel
-- hwloc
-- hwloc-devel
-- hwloc-gui
-- json-c-devel
-- libcurl-devel
-- libevent-devel
-- libibmad
-- libibumad
-- libyaml-devel
-- lua
-- lua-devel
-- lz4-devel
-- man2html-core
-- ncurses-devel
-- numactl
-- numactl-devel
-- openssl-devel
-- pam-devel
-- perl-ExtUtils-MakeMaker
-- readline-devel
-- rrdtool-devel
-- perl-devel
-- perl-ExtUtils-ParseXS
-- perl-ExtUtils-Embed
+kernel_packages:
+- kernel
+- kernel-core
+- kernel-devel
+- kernel-headers
+- kernel-modules*
+- kernel-tools*
+
+rdma_packages:
+- rdma-core*
+- libibverbs*
+- librdmacm*
+- libibumad*
+- infiniband-diags*

--- a/ansible/group_vars/os_redhat.yml
+++ b/ansible/group_vars/os_redhat.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) SchedMD LLC.
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,32 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-slurm_packages:
-- cifs-utils
-- gtk2-devel
-- hdf5-devel
-- http-parser-devel
-- hwloc
-- hwloc-devel
-- hwloc-gui
-- json-c-devel
-- libcurl-devel
-- libevent-devel
-- libibmad
-- libibumad
-- libyaml-devel
-- lua
-- lua-devel
-- lz4-devel
-- man2html-core
-- ncurses-devel
-- numactl
-- numactl-devel
-- openssl-devel
-- pam-devel
-- perl-ExtUtils-MakeMaker
-- readline-devel
-- rrdtool-devel
-- perl-devel
-- perl-ExtUtils-ParseXS
-- perl-ExtUtils-Embed
+kernel_packages:
+- kernel
+- kernel-core
+- kernel-devel
+- kernel-headers
+- kernel-modules*
+- kernel-tools*
+
+rdma_packages:
+- rdma-core*
+- libibverbs*
+- librdmacm*
+- libibumad*
+- infiniband-diags*

--- a/ansible/group_vars/os_rocky.yml
+++ b/ansible/group_vars/os_rocky.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) SchedMD LLC.
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,32 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-slurm_packages:
-- cifs-utils
-- gtk2-devel
-- hdf5-devel
-- http-parser-devel
-- hwloc
-- hwloc-devel
-- hwloc-gui
-- json-c-devel
-- libcurl-devel
-- libevent-devel
-- libibmad
-- libibumad
-- libyaml-devel
-- lua
-- lua-devel
-- lz4-devel
-- man2html-core
-- ncurses-devel
-- numactl
-- numactl-devel
-- openssl-devel
-- pam-devel
-- perl-ExtUtils-MakeMaker
-- readline-devel
-- rrdtool-devel
-- perl-devel
-- perl-ExtUtils-ParseXS
-- perl-ExtUtils-Embed
+kernel_packages:
+- kernel
+- kernel-core
+- kernel-devel
+- kernel-headers
+- kernel-modules*
+- kernel-tools*
+
+rdma_packages:
+- rdma-core*
+- libibverbs*
+- librdmacm*
+- libibumad*
+- infiniband-diags*

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -168,14 +168,14 @@
   - name: Align and pre-install exact CIQ RDMA/verbs stack to match base driver (RedHat/Rocky)
     ansible.builtin.dnf:
       name:
-      - "rdma-core-{{ rdma_core_ver.stdout | trim }}"
-      - "rdma-core-devel-{{ rdma_core_ver.stdout | trim }}"
-      - "libibverbs-{{ rdma_core_ver.stdout | trim }}"
-      - "libibverbs-utils-{{ rdma_core_ver.stdout | trim }}"
-      - "librdmacm-{{ rdma_core_ver.stdout | trim }}"
-      - "librdmacm-utils-{{ rdma_core_ver.stdout | trim }}"
-      - "libibumad-{{ rdma_core_ver.stdout | trim }}"
-      - "infiniband-diags-{{ rdma_core_ver.stdout | trim }}"
+      - "rdma-core-{{ rdma_core_ver.stdout | default('') | trim }}"
+      - "rdma-core-devel-{{ rdma_core_ver.stdout | default('') | trim }}"
+      - "libibverbs-{{ rdma_core_ver.stdout | default('') | trim }}"
+      - "libibverbs-utils-{{ rdma_core_ver.stdout | default('') | trim }}"
+      - "librdmacm-{{ rdma_core_ver.stdout | default('') | trim }}"
+      - "librdmacm-utils-{{ rdma_core_ver.stdout | default('') | trim }}"
+      - "libibumad-{{ rdma_core_ver.stdout | default('') | trim }}"
+      - "infiniband-diags-{{ rdma_core_ver.stdout | default('') | trim }}"
       state: present
       allow_erasing: true
       disable_excludes: ciq-sigcloud-next
@@ -184,13 +184,28 @@
     - ansible_os_family == "RedHat" and ansible_distribution_major_version in ['8', '9']
     - rdma_core_ver.rc | default(-1) == 0 and 'ciq' in rdma_core_ver.stdout | default('')
 
+  - name: Install build dependencies for perftest (RedHat/Rocky)
+    ansible.builtin.dnf:
+      name:
+      - git
+      - autoconf
+      - automake
+      - libtool
+      - make
+      - gcc
+      - pciutils-devel
+      state: present
+      disable_excludes: all
+    when:
+    - ansible_os_family == "RedHat" and ansible_distribution_major_version in ['8', '9']
+    - rdma_core_ver.rc | default(-1) == 0 and 'ciq' in rdma_core_ver.stdout | default('')
+
   - name: Build and install perftest (ib_send_bw) from source against locked CIQ verbs headers (RedHat/Rocky)
     ansible.builtin.shell: |
       set -e
-      dnf --disableexcludes=all install -y git autoconf automake libtool make gcc pciutils-devel
       rm -rf /tmp/perftest_build
       git clone --depth=1 --branch v24.07.0-0.43 https://github.com/linux-rdma/perftest.git /tmp/perftest_build
-      cd /tmp/perftest_build && ./autogen.sh && ./configure --prefix=/usr/local && make -j && make install
+      cd /tmp/perftest_build && ./autogen.sh && ./configure --prefix=/usr/local && make -j {{ ansible_processor_vcpus }} && make install
       rm -rf /tmp/perftest_build
     args:
       creates: /usr/local/bin/ib_send_bw
@@ -210,14 +225,23 @@
     changed_when: "'Adding versionlock on:' in versionlock_rdma_add.stdout"
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version in ['8', '9']
 
-  - name: Exclude stock perftest and libfabric RPMs to protect custom base image binaries (RedHat/Rocky)
+  - name: Get existing excludepkgs from dnf.conf (RedHat/Rocky)
+    ansible.builtin.shell: grep -Ei '^[[:space:]]*excludepkgs[[:space:]]*=' /etc/dnf/dnf.conf | head -n 1 | sed 's/^[^=]*=[[:space:]]*//'
+    register: existing_excludepkgs
+    changed_when: false
+    failed_when: false
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version in ['8', '9']
+
+  - name: Exclude stock perftest and libfabric RPMs while preserving existing exclusions (RedHat/Rocky)
     ansible.builtin.ini_file:
       path: /etc/dnf/dnf.conf
       section: main
       option: excludepkgs
-      value: 'perftest* libfabric*'
+      value: "{{ (existing_excludepkgs.stdout | default('') | trim ~ ' perftest* libfabric*') | trim }}"
       mode: '0644'
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version in ['8', '9']
+    when:
+    - ansible_os_family == "RedHat" and ansible_distribution_major_version in ['8', '9']
+    - "'perftest*' not in (existing_excludepkgs.stdout | default(''))"
 
   roles:
   - motd

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -140,6 +140,85 @@
     loop: "{{ kernel_packages }}"
     when: ansible_os_family == "Debian"
 
+  - name: Install dnf versionlock plugin before running playbook (RedHat/Rocky)
+    ansible.builtin.package:
+      name: python3-dnf-plugin-versionlock
+      state: present
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version in ['8', '9']
+
+  - name: Freeze kernel before running playbook (RedHat/Rocky)
+    ansible.builtin.command:
+      argv:
+      - dnf
+      - versionlock
+      - add
+      - "{{ item }}"
+    loop: "{{ kernel_packages }}"
+    register: versionlock_add
+    changed_when: "'Adding versionlock on:' in versionlock_add.stdout"
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version in ['8', '9']
+
+  - name: Get installed CIQ rdma-core version (RedHat/Rocky)
+    ansible.builtin.command: rpm -q --qf '%{VERSION}-%{RELEASE}' rdma-core
+    register: rdma_core_ver
+    failed_when: false
+    changed_when: false
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version in ['8', '9']
+
+  - name: Align and pre-install exact CIQ RDMA/verbs stack to match base driver (RedHat/Rocky)
+    ansible.builtin.dnf:
+      name:
+      - "rdma-core-{{ rdma_core_ver.stdout | trim }}"
+      - "rdma-core-devel-{{ rdma_core_ver.stdout | trim }}"
+      - "libibverbs-{{ rdma_core_ver.stdout | trim }}"
+      - "libibverbs-utils-{{ rdma_core_ver.stdout | trim }}"
+      - "librdmacm-{{ rdma_core_ver.stdout | trim }}"
+      - "librdmacm-utils-{{ rdma_core_ver.stdout | trim }}"
+      - "libibumad-{{ rdma_core_ver.stdout | trim }}"
+      - "infiniband-diags-{{ rdma_core_ver.stdout | trim }}"
+      state: present
+      allow_erasing: true
+      disable_excludes: ciq-sigcloud-next
+      disable_plugin: protected-kmods
+    when:
+    - ansible_os_family == "RedHat" and ansible_distribution_major_version in ['8', '9']
+    - rdma_core_ver.rc | default(-1) == 0 and 'ciq' in rdma_core_ver.stdout | default('')
+
+  - name: Build and install perftest (ib_send_bw) from source against locked CIQ verbs headers (RedHat/Rocky)
+    ansible.builtin.shell: |
+      set -e
+      dnf --disableexcludes=all install -y git autoconf automake libtool make gcc pciutils-devel
+      rm -rf /tmp/perftest_build
+      git clone --depth=1 --branch v24.07.0-0.43 https://github.com/linux-rdma/perftest.git /tmp/perftest_build
+      cd /tmp/perftest_build && ./autogen.sh && ./configure --prefix=/usr/local && make -j && make install
+      rm -rf /tmp/perftest_build
+    args:
+      creates: /usr/local/bin/ib_send_bw
+    when:
+    - ansible_os_family == "RedHat" and ansible_distribution_major_version in ['8', '9']
+    - rdma_core_ver.rc | default(-1) == 0 and 'ciq' in rdma_core_ver.stdout | default('')
+
+  - name: Freeze RDMA/interconnect stack before running playbook (RedHat/Rocky)
+    ansible.builtin.command:
+      argv:
+      - dnf
+      - versionlock
+      - add
+      - "{{ item }}"
+    loop: "{{ rdma_packages | default([]) }}"
+    register: versionlock_rdma_add
+    changed_when: "'Adding versionlock on:' in versionlock_rdma_add.stdout"
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version in ['8', '9']
+
+  - name: Exclude stock perftest and libfabric RPMs to protect custom base image binaries (RedHat/Rocky)
+    ansible.builtin.ini_file:
+      path: /etc/dnf/dnf.conf
+      section: main
+      option: excludepkgs
+      value: 'perftest* libfabric*'
+      mode: '0644'
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version in ['8', '9']
+
   roles:
   - motd
   - common
@@ -203,4 +282,19 @@
     loop: "{{ kernel_packages }}"
     when:
     - ansible_os_family == "Debian"
+    - allow_kernel_upgrades
+
+  - name: Re-enable kernel upgrades by dnf upgrade (RedHat/Rocky)
+    ansible.builtin.command:
+      argv:
+      - dnf
+      - versionlock
+      - delete
+      - "{{ item }}"
+    loop: "{{ kernel_packages }}"
+    register: versionlock_del
+    failed_when: false
+    changed_when: "'No package found' not in versionlock_del.stderr and 'No package found' not in versionlock_del.stdout"
+    when:
+    - ansible_os_family == "RedHat" and ansible_distribution_major_version in ['8', '9']
     - allow_kernel_upgrades

--- a/ansible/roles/kernel/tasks/os/redhat-8.yml
+++ b/ansible/roles/kernel/tasks/os/redhat-8.yml
@@ -23,7 +23,7 @@
     - kernel-tools-libs
     #- kernel-tools-libs-devel
     - '{{ ansible_distribution | lower }}-release'
-    state: latest
+    state: present
     update_cache: yes
 - block:
   - name: Reboot

--- a/ansible/roles/kernel/tasks/os/redhat-9.yml
+++ b/ansible/roles/kernel/tasks/os/redhat-9.yml
@@ -23,7 +23,7 @@
     - kernel-tools-libs
     #- kernel-tools-libs-devel
     - '{{ ansible_distribution | lower }}-release'
-    state: latest
+    state: present
     update_cache: yes
 - block:
   - name: Reboot

--- a/ansible/roles/slurm/vars/redhat-8.yml
+++ b/ansible/roles/slurm/vars/redhat-8.yml
@@ -39,3 +39,6 @@ slurm_packages:
 - perl-ExtUtils-MakeMaker
 - readline-devel
 - rrdtool-devel
+- perl-devel
+- perl-ExtUtils-ParseXS
+- perl-ExtUtils-Embed

--- a/ansible/roles/slurm/vars/redhat-9.yml
+++ b/ansible/roles/slurm/vars/redhat-9.yml
@@ -15,7 +15,6 @@
 
 slurm_packages:
 - cifs-utils
-- gtk2-devel
 - hdf5-devel
 - http-parser-devel
 - hwloc
@@ -40,3 +39,6 @@ slurm_packages:
 - perl-ExtUtils-MakeMaker
 - readline-devel
 - rrdtool-devel
+- perl-devel
+- perl-ExtUtils-ParseXS
+- perl-ExtUtils-Embed

--- a/packer/builds/hpc-rocky-linux-9.hcl
+++ b/packer/builds/hpc-rocky-linux-9.hcl
@@ -1,4 +1,3 @@
----
 # Copyright (C) SchedMD LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,32 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-slurm_packages:
-- cifs-utils
-- gtk2-devel
-- hdf5-devel
-- http-parser-devel
-- hwloc
-- hwloc-devel
-- hwloc-gui
-- json-c-devel
-- libcurl-devel
-- libevent-devel
-- libibmad
-- libibumad
-- libyaml-devel
-- lua
-- lua-devel
-- lz4-devel
-- man2html-core
-- ncurses-devel
-- numactl
-- numactl-devel
-- openssl-devel
-- pam-devel
-- perl-ExtUtils-MakeMaker
-- readline-devel
-- rrdtool-devel
-- perl-devel
-- perl-ExtUtils-ParseXS
-- perl-ExtUtils-Embed
+###########
+# GENERAL #
+###########
+
+project_id = "<PROJECT_ID>"
+zone       = "us-central1-a"
+
+#########
+# IMAGE #
+#########
+
+# NOTE: Your Project ID will be automatically appended
+source_image_project_id = "cloud-hpc-image-public"
+
+#source_image        = null
+source_image_family = "hpc-rocky-linux-9"
+
+# *NOT* intended for production use
+# skip_create_image = true
+
+#############
+# PROVISION #
+#############
+
+# slurm_version = null


### PR DESCRIPTION
This change contains the following

- Freeze Rocky/RedHat kernel packages in Ansible to prevent  Lustre DKMS build crashes against Rocky 9.8 (kernel 687).
- Align and freeze the user-space RDMA library stack (libibverbs, rdma-core) to match the out-of-tree base image driver (v57_ciq) at build time, preventing -ENOSPC ioctl initialization hangs on H4D instances.
- Build perftest (ib_send_bw) from source against locked verbs headers.
- Keep RDMA stack versionlocked on final image to prevent post-boot drift.