### PR TITLE
Modularize package installation

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -182,7 +182,7 @@
   - mariadb
   - libjwt
   - role: lmod
-    when: install_lmod
+    when: install_lmod | default(true)
   - role: slurm
     when: install_slurm
   - role: slurmcmd

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -129,12 +129,10 @@
       that: not (install_lustre and install_managed_lustre)
       fail_msg: |
         install_lustre and install_managed_lustre are mutually exclusive Options
-  - name: Resolve OMPI and Lmod dependencies
+  - name: Warn on OMPI and Lmod dependencies
+    ansible.builtin.debug:
+      msg: "WARNING: install_ompi is true but install_lmod is false. OpenMPI requires Lmod to load properly. Automatically installing Lmod as a dependency."
     when: install_ompi and not install_lmod
-    block:
-    - name: Warn on OMPI and Lmod dependencies
-      ansible.builtin.debug:
-        msg: "WARNING: install_ompi is true but install_lmod is false. OpenMPI requires Lmod to load properly. Automatically installing Lmod as a dependency."
   - name: Warn if scl-utils installs env-modules implicitly
     ansible.builtin.debug:
       msg: "WARNING: install_environment_modules is false but install_scl_utils is true. scl-utils will install environment-modules by default."

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -129,26 +129,19 @@
       that: not (install_lustre and install_managed_lustre)
       fail_msg: |
         install_lustre and install_managed_lustre are mutually exclusive Options
-  - name: Record OMPI and Lmod dependency warning
-    ansible.builtin.set_fact:
-      warning_ompi_lmod: true
+  - name: Resolve OMPI and Lmod dependencies
     when: install_ompi and not install_lmod
-  - name: Warn on OMPI and Lmod dependencies
-    ansible.builtin.debug:
-      msg: "WARNING: install_ompi is true but install_lmod is false. OpenMPI requires Lmod to load properly. Automatically enabling install_lmod."
-    when: warning_ompi_lmod | default(false)
-  - name: Automatically enable install_lmod for OMPI
-    ansible.builtin.set_fact:
-      install_lmod: true
-    when: warning_ompi_lmod | default(false)
-  - name: Record scl-utils and env-modules warning
-    ansible.builtin.set_fact:
-      warning_scl_env_modules: true
-    when: not install_environment_modules and install_scl_utils
+    block:
+    - name: Warn on OMPI and Lmod dependencies
+      ansible.builtin.debug:
+        msg: "WARNING: install_ompi is true but install_lmod is false. OpenMPI requires Lmod to load properly. Automatically enabling install_lmod."
+    - name: Automatically enable install_lmod for OMPI
+      ansible.builtin.set_fact:
+        install_lmod: true
   - name: Warn if scl-utils installs env-modules implicitly
     ansible.builtin.debug:
       msg: "WARNING: install_environment_modules is false but install_scl_utils is true. scl-utils will install environment-modules by default."
-    when: warning_scl_env_modules | default(false)
+    when: not install_environment_modules and install_scl_utils
   - name: Check Managed Lustre Install Options
     when: install_managed_lustre
     ansible.builtin.assert:
@@ -242,15 +235,3 @@
     when:
     - ansible_os_family == "Debian"
     - allow_kernel_upgrades
-  - name: Append OMPI/Lmod warning to MOTD
-    ansible.builtin.lineinfile:
-      path: /etc/motd
-      line: "WARNING: install_ompi was true but install_lmod was false. OpenMPI requires Lmod to load properly. Automatically enabled install_lmod."
-      create: yes
-    when: warning_ompi_lmod | default(false)
-  - name: Append scl-utils warning to MOTD
-    ansible.builtin.lineinfile:
-      path: /etc/motd
-      line: "WARNING: install_environment_modules was false but install_scl_utils was true. scl-utils installed environment-modules by default."
-      create: yes
-    when: warning_scl_env_modules | default(false)

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -135,9 +135,6 @@
     - name: Warn on OMPI and Lmod dependencies
       ansible.builtin.debug:
         msg: "WARNING: install_ompi is true but install_lmod is false. OpenMPI requires Lmod to load properly. Automatically enabling install_lmod."
-    - name: Automatically enable install_lmod for OMPI
-      ansible.builtin.set_fact:
-        install_lmod: true
   - name: Warn if scl-utils installs env-modules implicitly
     ansible.builtin.debug:
       msg: "WARNING: install_environment_modules is false but install_scl_utils is true. scl-utils will install environment-modules by default."
@@ -195,7 +192,7 @@
   - mariadb
   - libjwt
   - role: lmod
-    when: install_lmod | default(true)
+    when: (install_lmod | default(true)) or (install_ompi | default(false))
   - role: slurm
     when: install_slurm
   - role: slurmcmd

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -129,6 +129,18 @@
       that: not (install_lustre and install_managed_lustre)
       fail_msg: |
         install_lustre and install_managed_lustre are mutually exclusive Options
+  - name: Warn on OMPI and Lmod dependencies
+    ansible.builtin.debug:
+      msg: "WARNING: install_ompi is true but install_lmod is false. OpenMPI requires Lmod to load properly. Automatically enabling install_lmod."
+    when: install_ompi and not install_lmod
+  - name: Automatically enable install_lmod for OMPI
+    ansible.builtin.set_fact:
+      install_lmod: true
+    when: install_ompi and not install_lmod
+  - name: Warn if scl-utils installs env-modules implicitly
+    ansible.builtin.debug:
+      msg: "WARNING: install_environment_modules is false but install_scl_utils is true. scl-utils will install environment-modules by default."
+    when: not install_environment_modules and install_scl_utils
   - name: Check Managed Lustre Install Options
     when: install_managed_lustre
     ansible.builtin.assert:

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -66,7 +66,6 @@
     install_pyxis: true
     allow_kernel_upgrades: true
     install_lmod: true
-    lmod_source: "git"
     install_environment_modules: false
     install_scl_utils: false
 

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -65,6 +65,10 @@
     install_pmix: true
     install_pyxis: true
     allow_kernel_upgrades: true
+    install_lmod: true
+    lmod_source: "git"
+    install_environment_modules: false
+    install_scl_utils: false
 
   pre_tasks:
   - name: Minimum Ansible Version Check
@@ -178,7 +182,8 @@
     - install_munge
   - mariadb
   - libjwt
-  - lmod
+  - role: lmod
+    when: install_lmod
   - role: slurm
     when: install_slurm
   - role: slurmcmd

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -129,18 +129,26 @@
       that: not (install_lustre and install_managed_lustre)
       fail_msg: |
         install_lustre and install_managed_lustre are mutually exclusive Options
+  - name: Record OMPI and Lmod dependency warning
+    ansible.builtin.set_fact:
+      warning_ompi_lmod: true
+    when: install_ompi and not install_lmod
   - name: Warn on OMPI and Lmod dependencies
     ansible.builtin.debug:
       msg: "WARNING: install_ompi is true but install_lmod is false. OpenMPI requires Lmod to load properly. Automatically enabling install_lmod."
-    when: install_ompi and not install_lmod
+    when: warning_ompi_lmod | default(false)
   - name: Automatically enable install_lmod for OMPI
     ansible.builtin.set_fact:
       install_lmod: true
-    when: install_ompi and not install_lmod
+    when: warning_ompi_lmod | default(false)
+  - name: Record scl-utils and env-modules warning
+    ansible.builtin.set_fact:
+      warning_scl_env_modules: true
+    when: not install_environment_modules and install_scl_utils
   - name: Warn if scl-utils installs env-modules implicitly
     ansible.builtin.debug:
       msg: "WARNING: install_environment_modules is false but install_scl_utils is true. scl-utils will install environment-modules by default."
-    when: not install_environment_modules and install_scl_utils
+    when: warning_scl_env_modules | default(false)
   - name: Check Managed Lustre Install Options
     when: install_managed_lustre
     ansible.builtin.assert:
@@ -234,3 +242,15 @@
     when:
     - ansible_os_family == "Debian"
     - allow_kernel_upgrades
+  - name: Append OMPI/Lmod warning to MOTD
+    ansible.builtin.lineinfile:
+      path: /etc/motd
+      line: "WARNING: install_ompi was true but install_lmod was false. OpenMPI requires Lmod to load properly. Automatically enabled install_lmod."
+      create: yes
+    when: warning_ompi_lmod | default(false)
+  - name: Append scl-utils warning to MOTD
+    ansible.builtin.lineinfile:
+      path: /etc/motd
+      line: "WARNING: install_environment_modules was false but install_scl_utils was true. scl-utils installed environment-modules by default."
+      create: yes
+    when: warning_scl_env_modules | default(false)

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -138,7 +138,7 @@
   - name: Warn if scl-utils installs env-modules implicitly
     ansible.builtin.debug:
       msg: "WARNING: install_environment_modules is false but install_scl_utils is true. scl-utils will install environment-modules by default."
-    when: not install_environment_modules and install_scl_utils
+    when: not install_environment_modules and install_scl_utils and ansible_os_family == 'RedHat'
   - name: Check Managed Lustre Install Options
     when: install_managed_lustre
     ansible.builtin.assert:
@@ -192,7 +192,7 @@
   - mariadb
   - libjwt
   - role: lmod
-    when: (install_lmod | default(true)) or (install_ompi | default(false))
+    when: install_lmod or install_ompi
   - role: slurm
     when: install_slurm
   - role: slurmcmd

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -134,7 +134,7 @@
     block:
     - name: Warn on OMPI and Lmod dependencies
       ansible.builtin.debug:
-        msg: "WARNING: install_ompi is true but install_lmod is false. OpenMPI requires Lmod to load properly. Automatically enabling install_lmod."
+        msg: "WARNING: install_ompi is true but install_lmod is false. OpenMPI requires Lmod to load properly. Automatically installing Lmod as a dependency."
   - name: Warn if scl-utils installs env-modules implicitly
     ansible.builtin.debug:
       msg: "WARNING: install_environment_modules is false but install_scl_utils is true. scl-utils will install environment-modules by default."

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -57,17 +57,17 @@
     owner: root
     mode: 0660
 
+- name: Manage environment-modules package
+  package:
+    name: environment-modules
+    state: "{{ 'present' if ((install_environment_modules | default(false)) or ((install_scl_utils | default(false)) and ansible_os_family == 'RedHat')) else 'absent' }}"
+  when: ansible_os_family in ['RedHat', 'Debian']
+
 - name: Manage scl-utils package
   package:
     name: scl-utils
     state: "{{ 'present' if (install_scl_utils | default(false)) else 'absent' }}"
   when: ansible_os_family == 'RedHat'
-
-- name: Manage environment-modules package
-  package:
-    name: environment-modules
-    state: "{{ 'present' if (install_environment_modules | default(false)) else 'absent' }}"
-  when: ansible_os_family in ['RedHat', 'Debian']
 
 - name: Ensure Lmod RPM is absent to avoid conflicts
   package:

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -56,3 +56,15 @@
     group: root
     owner: root
     mode: 0660
+
+- name: Manage environment-modules package
+  package:
+    name: environment-modules
+    state: "{{ 'present' if install_environment_modules else 'absent' }}"
+  when: ansible_os_family == 'RedHat'
+
+- name: Manage scl-utils package
+  package:
+    name: scl-utils
+    state: "{{ 'present' if install_scl_utils else 'absent' }}"
+  when: ansible_os_family == 'RedHat'

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -60,12 +60,11 @@
 - name: Manage environment-modules package
   package:
     name: environment-modules
-    state: "{{ 'present' if install_environment_modules else 'absent' }}"
+    state: "{{ 'present' if (install_environment_modules | default(false)) else 'absent' }}"
   when: ansible_os_family in ['RedHat', 'Debian']
 
 - name: Manage scl-utils package
   package:
     name: scl-utils
-    state: "{{ 'present' if install_scl_utils else 'absent' }}"
+    state: "{{ 'present' if (install_scl_utils | default(false)) else 'absent' }}"
   when: ansible_os_family == 'RedHat'
-

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -57,14 +57,20 @@
     owner: root
     mode: 0660
 
+- name: Manage scl-utils package
+  package:
+    name: scl-utils
+    state: "{{ 'present' if (install_scl_utils | default(false)) else 'absent' }}"
+  when: ansible_os_family == 'RedHat'
+
 - name: Manage environment-modules package
   package:
     name: environment-modules
     state: "{{ 'present' if (install_environment_modules | default(false)) else 'absent' }}"
   when: ansible_os_family in ['RedHat', 'Debian']
 
-- name: Manage scl-utils package
+- name: Ensure Lmod RPM is absent to avoid conflicts
   package:
-    name: scl-utils
-    state: "{{ 'present' if (install_scl_utils | default(false)) else 'absent' }}"
-  when: ansible_os_family == 'RedHat'
+    name: Lmod
+    state: absent
+  when: ansible_os_family in ['RedHat', 'Debian']

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -60,7 +60,7 @@
 - name: Manage environment-modules package
   package:
     name: environment-modules
-    state: "{{ 'present' if ((install_environment_modules | default(false)) or ((install_scl_utils | default(false)) and ansible_os_family == 'RedHat')) else 'absent' }}"
+    state: "{{ 'present' if (install_environment_modules | default(false)) else 'absent' }}"
   when: ansible_os_family in ['RedHat', 'Debian']
 
 - name: Manage scl-utils package
@@ -69,8 +69,8 @@
     state: "{{ 'present' if (install_scl_utils | default(false)) else 'absent' }}"
   when: ansible_os_family == 'RedHat'
 
-- name: Ensure Lmod RPM is absent to avoid conflicts
+- name: Ensure OS-provided Lmod package is absent to avoid conflicts
   package:
-    name: Lmod
+    name: "{{ 'Lmod' if ansible_os_family == 'RedHat' else 'lmod' }}"
     state: absent
   when: ansible_os_family in ['RedHat', 'Debian']

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -61,10 +61,11 @@
   package:
     name: environment-modules
     state: "{{ 'present' if install_environment_modules else 'absent' }}"
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family in ['RedHat', 'Debian']
 
 - name: Manage scl-utils package
   package:
     name: scl-utils
     state: "{{ 'present' if install_scl_utils else 'absent' }}"
   when: ansible_os_family == 'RedHat'
+

--- a/ansible/roles/lmod/tasks/main.yml
+++ b/ansible/roles/lmod/tasks/main.yml
@@ -26,8 +26,8 @@
     path: '{{item}}'
     state: directory
   loop:
-    - '{{paths.apps}}'
-    - '{{paths.modulefiles}}'
+  - '{{paths.apps}}'
+  - '{{paths.modulefiles}}'
 
 - name: Git Clone
   git:

--- a/ansible/roles/lmod/tasks/main.yml
+++ b/ansible/roles/lmod/tasks/main.yml
@@ -29,62 +29,40 @@
     - '{{paths.apps}}'
     - '{{paths.modulefiles}}'
 
-- name: Install Lmod via package manager
-  package:
-    name: "{{ 'Lmod' if ansible_os_family == 'RedHat' else 'lmod' }}"
-    state: present
-  when: lmod_source == 'rpm'
+- name: Git Clone
+  git:
+    repo: '{{lmod_git_url}}'
+    dest: '{{lmod_paths.src}}'
+    version: '{{lmod_version}}'
+    clone: yes
+    depth: '1'
 
-- name: Ensure OS modulefiles directory exists
-  file:
-    path: /usr/share/modulefiles
-    state: directory
-  when: lmod_source == 'rpm'
+- name: Create Modulespath
+  template:
+    src: modulespath.j2
+    dest: '{{paths.apps}}/lmod/.modulespath'
+    mode: 0644
 
-- name: Link custom modulefiles to system default path (RPM)
+- name: Configure
+  shell:
+    cmd: >
+      {{lmod_paths.src}}/configure
+      --prefix={{paths.apps}}
+      --with-ModulePathInit={{paths.apps}}/lmod/.modulespath
+      > /dev/null
+    chdir: '{{lmod_paths.src}}'
+
+- name: Make Install
+  shell:
+    cmd: make install > /dev/null
+    chdir: '{{lmod_paths.src}}'
+
+- name: Symbolic Link
   file:
-    src: '{{paths.modulefiles}}'
-    dest: /usr/share/modulefiles/slurm-gcp
+    src: '{{item.src}}'
+    dest: '{{item.dest}}'
     state: link
-  when: lmod_source == 'rpm'
-
-- name: Install Lmod from source
-  when: lmod_source == 'git'
-  block:
-  - name: Git Clone
-    git:
-      repo: '{{lmod_git_url}}'
-      dest: '{{lmod_paths.src}}'
-      version: '{{lmod_version}}'
-      clone: yes
-      depth: '1'
-
-  - name: Create Modulespath
-    template:
-      src: modulespath.j2
-      dest: '{{paths.apps}}/lmod/.modulespath'
-      mode: 0644
-
-  - name: Configure
-    shell:
-      cmd: >
-        {{lmod_paths.src}}/configure
-        --prefix={{paths.apps}}
-        --with-ModulePathInit={{paths.apps}}/lmod/.modulespath
-        > /dev/null
-      chdir: '{{lmod_paths.src}}'
-
-  - name: Make Install
-    shell:
-      cmd: make install > /dev/null
-      chdir: '{{lmod_paths.src}}'
-
-  - name: Symbolic Link
-    file:
-      src: '{{item.src}}'
-      dest: '{{item.dest}}'
-      state: link
-    with_items:
-    - {src: '{{lmod_paths.build}}/init/profile', dest: /etc/profile.d/z00_lmod.sh}
-    - {src: '{{lmod_paths.build}}/init/cshrc', dest: /etc/profile.d/z00_lmod.csh,}
-    # - { src: "{{lmod_paths.build}}/init/profile.fish", dest: "/etc/fish/conf.d/z00_lmod.fish" }
+  with_items:
+  - {src: '{{lmod_paths.build}}/init/profile', dest: /etc/profile.d/z00_lmod.sh}
+  - {src: '{{lmod_paths.build}}/init/cshrc', dest: /etc/profile.d/z00_lmod.csh,}
+  # - { src: "{{lmod_paths.build}}/init/profile.fish", dest: "/etc/fish/conf.d/z00_lmod.fish" }

--- a/ansible/roles/lmod/tasks/main.yml
+++ b/ansible/roles/lmod/tasks/main.yml
@@ -27,6 +27,19 @@
     state: present
   when: lmod_source == 'rpm'
 
+- name: Ensure OS modulefiles directory exists
+  file:
+    path: /usr/share/modulefiles
+    state: directory
+  when: lmod_source == 'rpm'
+
+- name: Link custom modulefiles to system default path (RPM)
+  file:
+    src: '{{paths.modulefiles}}'
+    dest: /usr/share/modulefiles/slurm-gcp
+    state: link
+  when: lmod_source == 'rpm'
+
 - name: Install Lmod from source
   when: lmod_source == 'git'
   block:

--- a/ansible/roles/lmod/tasks/main.yml
+++ b/ansible/roles/lmod/tasks/main.yml
@@ -21,7 +21,7 @@
   - os/{{ ansible_distribution|lower }}.yml
   - os/{{ ansible_os_family|lower }}.yml
 
-- name: Ensure custom modulefiles directory exists
+- name: Mkdir
   file:
     path: '{{item}}'
     state: directory

--- a/ansible/roles/lmod/tasks/main.yml
+++ b/ansible/roles/lmod/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: Install Lmod via package manager
   package:
-    name: Lmod
+    name: "{{ 'Lmod' if ansible_os_family == 'RedHat' else 'lmod' }}"
     state: present
   when: lmod_source == 'rpm'
 
@@ -66,23 +66,12 @@
       cmd: make install > /dev/null
       chdir: '{{lmod_paths.src}}'
 
-- name: Disable conflicting default module/scl profile scripts
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: absent
-  loop:
-  - /etc/profile.d/modules.sh
-  - /etc/profile.d/modules.csh
-  - /etc/profile.d/scl-init.sh
-  - /etc/profile.d/scl.sh
-  when: ansible_os_family == 'RedHat'
-
-- name: Symbolic Link
-  file:
-    src: '{{item.src}}'
-    dest: '{{item.dest}}'
-    state: link
-  with_items:
-  - {src: '{{lmod_paths.build}}/init/profile', dest: /etc/profile.d/z00_lmod.sh}
-  - {src: '{{lmod_paths.build}}/init/cshrc', dest: /etc/profile.d/z00_lmod.csh,}
-  # - { src: "{{lmod_paths.build}}/init/profile.fish", dest: "/etc/fish/conf.d/z00_lmod.fish" }
+  - name: Symbolic Link
+    file:
+      src: '{{item.src}}'
+      dest: '{{item.dest}}'
+      state: link
+    with_items:
+    - {src: '{{lmod_paths.build}}/init/profile', dest: /etc/profile.d/z00_lmod.sh}
+    - {src: '{{lmod_paths.build}}/init/cshrc', dest: /etc/profile.d/z00_lmod.csh,}
+    # - { src: "{{lmod_paths.build}}/init/profile.fish", dest: "/etc/fish/conf.d/z00_lmod.fish" }

--- a/ansible/roles/lmod/tasks/main.yml
+++ b/ansible/roles/lmod/tasks/main.yml
@@ -21,41 +21,50 @@
   - os/{{ ansible_distribution|lower }}.yml
   - os/{{ ansible_os_family|lower }}.yml
 
-- name: Mkdir
-  file:
-    path: '{{item}}'
-    state: directory
-  loop:
-  - '{{paths.apps}}'
-  - '{{paths.modulefiles}}'
+- name: Install Lmod via package manager
+  package:
+    name: Lmod
+    state: present
+  when: lmod_source == 'rpm'
 
-- name: Git Clone
-  git:
-    repo: '{{lmod_git_url}}'
-    dest: '{{lmod_paths.src}}'
-    version: '{{lmod_version}}'
-    clone: yes
-    depth: '1'
+- name: Install Lmod from source
+  when: lmod_source == 'git'
+  block:
+  - name: Mkdir
+    file:
+      path: '{{item}}'
+      state: directory
+    loop:
+    - '{{paths.apps}}'
+    - '{{paths.modulefiles}}'
 
-- name: Create Modulespath
-  template:
-    src: modulespath.j2
-    dest: '{{paths.apps}}/lmod/.modulespath'
-    mode: 0644
+  - name: Git Clone
+    git:
+      repo: '{{lmod_git_url}}'
+      dest: '{{lmod_paths.src}}'
+      version: '{{lmod_version}}'
+      clone: yes
+      depth: '1'
 
-- name: Configure
-  shell:
-    cmd: >
-      {{lmod_paths.src}}/configure
-      --prefix={{paths.apps}}
-      --with-ModulePathInit={{paths.apps}}/lmod/.modulespath
-      > /dev/null
-    chdir: '{{lmod_paths.src}}'
+  - name: Create Modulespath
+    template:
+      src: modulespath.j2
+      dest: '{{paths.apps}}/lmod/.modulespath'
+      mode: 0644
 
-- name: Make Install
-  shell:
-    cmd: make install > /dev/null
-    chdir: '{{lmod_paths.src}}'
+  - name: Configure
+    shell:
+      cmd: >
+        {{lmod_paths.src}}/configure
+        --prefix={{paths.apps}}
+        --with-ModulePathInit={{paths.apps}}/lmod/.modulespath
+        > /dev/null
+      chdir: '{{lmod_paths.src}}'
+
+  - name: Make Install
+    shell:
+      cmd: make install > /dev/null
+      chdir: '{{lmod_paths.src}}'
 
 - name: Disable conflicting default module/scl profile scripts
   ansible.builtin.file:

--- a/ansible/roles/lmod/tasks/main.yml
+++ b/ansible/roles/lmod/tasks/main.yml
@@ -21,6 +21,14 @@
   - os/{{ ansible_distribution|lower }}.yml
   - os/{{ ansible_os_family|lower }}.yml
 
+- name: Ensure custom modulefiles directory exists
+  file:
+    path: '{{item}}'
+    state: directory
+  loop:
+    - '{{paths.apps}}'
+    - '{{paths.modulefiles}}'
+
 - name: Install Lmod via package manager
   package:
     name: "{{ 'Lmod' if ansible_os_family == 'RedHat' else 'lmod' }}"
@@ -43,14 +51,6 @@
 - name: Install Lmod from source
   when: lmod_source == 'git'
   block:
-  - name: Mkdir
-    file:
-      path: '{{item}}'
-      state: directory
-    loop:
-    - '{{paths.apps}}'
-    - '{{paths.modulefiles}}'
-
   - name: Git Clone
     git:
       repo: '{{lmod_git_url}}'

--- a/ansible/roles/ompi/meta/main.yml
+++ b/ansible/roles/ompi/meta/main.yml
@@ -16,7 +16,6 @@
 dependencies:
 - role: common
 - role: lmod
-  when: (install_lmod | default(true)) or (install_ompi | default(false))
 - role: slurm
   vars:
     handle_services: false

--- a/ansible/roles/ompi/meta/main.yml
+++ b/ansible/roles/ompi/meta/main.yml
@@ -16,7 +16,7 @@
 dependencies:
 - role: common
 - role: lmod
-  when: install_lmod
+  when: install_lmod | default(true)
 - role: slurm
   vars:
     handle_services: false

--- a/ansible/roles/ompi/meta/main.yml
+++ b/ansible/roles/ompi/meta/main.yml
@@ -16,6 +16,7 @@
 dependencies:
 - role: common
 - role: lmod
+  when: install_lmod
 - role: slurm
   vars:
     handle_services: false

--- a/ansible/roles/ompi/meta/main.yml
+++ b/ansible/roles/ompi/meta/main.yml
@@ -16,7 +16,7 @@
 dependencies:
 - role: common
 - role: lmod
-  when: install_lmod | default(true)
+  when: (install_lmod | default(true)) or (install_ompi | default(false))
 - role: slurm
   vars:
     handle_services: false


### PR DESCRIPTION
Introducing Ansible conditional flags to toggle the installation of environment management tools (Lmod, Environment-modules, and Scl-utils) within the Slurm-GCP deployment playbooks.

**Default values:
install_lmod: true
install_environment_modules: false
install_scl_utils: false**

We only support the source-compiled (git-based) installation of Lmod, rather than relying on the OS based RPM. Any existing Lmod RPM packages from pre-baked images are cleanly uninstalled prior to source-compiled installation to ensure there are no conflicts. This also fixes the initialization bug that was earlier introduced by rpm installed Lmod.

Bug script on the default values (Rocky linux 8): 
```
mkdir -p /tmp/hello
module use /tmp/hello
for i in sh csh tcsh zsh ksh bash "bash -l"; do
  echo "== SHELL is $i"
  echo 'echo $MODULEPATH' | $i
done
```
Output:
```
== SHELL is sh
/tmp/hello:/opt/apps/modulefiles
== SHELL is csh
./test_slurm_env.sh: line 29: csh: command not found
== SHELL is tcsh
./test_slurm_env.sh: line 29: tcsh: command not found
== SHELL is zsh
/tmp/hello:/opt/apps/modulefiles
== SHELL is ksh
./test_slurm_env.sh: line 29: ksh: command not found
== SHELL is bash
/tmp/hello:/opt/apps/modulefiles
== SHELL is bash -l
/tmp/hello:/opt/apps/modulefiles
```

For the scenario: 
**install_lmod: false, install_environment_modules: true, install_scl_utils: false**
```
for i in sh csh tcsh zsh ksh bash "bash -l"; do 
>   echo "== SHELL is $i"
>   echo 'echo $MODULEPATH' | $i 
> done
== SHELL is sh
/tmp/hello:/usr/share/Modules/modulefiles:/etc/modulefiles:/usr/share/modulefiles
== SHELL is csh
-bash: csh: command not found
== SHELL is tcsh
-bash: tcsh: command not found
== SHELL is zsh
/tmp/hello:/usr/share/Modules/modulefiles:/etc/modulefiles:/usr/share/modulefiles
== SHELL is ksh
-bash: ksh: command not found
== SHELL is bash
/tmp/hello:/usr/share/Modules/modulefiles:/etc/modulefiles:/usr/share/modulefiles
== SHELL is bash -l
/tmp/hello:/usr/share/Modules/modulefiles:/etc/modulefiles:/usr/share/modulefiles
[buildslurm-controller ~]$ 

```

**For the examples values install_lmod: true, install_environment_modules: true, install_scl_utils: false (rocky linux 9)**
```
[buildslurm-controller ~]$ module --version
Modules based on Lua: Version 8.5.9  2021-07-09 14:42 -05:00
    by Robert McLay mclay@tacc.utexas.edu

[buildslurm-controller ~]$ rpm -q environment-modules
environment-modules-5.3.0-2.el9.x86_64
[buildslurm-controller ~]$ module load openmpi
[buildslurm-controller ~]$ mpicc --version
gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-14)
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE 
```
Bug Script for above combination (**FIXED for all the combinations having install_scl_utils set to false**):
```
[buildslurm-controller ~]$ mkdir -p /tmp/hello
module use /tmp/hello
for i in sh csh tcsh zsh ksh bash "bash -l"; do
  echo "== SHELL is $i"
  echo 'echo $MODULEPATH' | $i
done
== SHELL is sh
/tmp/hello:/usr/share/Modules/modulefiles:/etc/modulefiles:/usr/share/modulefiles:/opt/apps/modulefiles
== SHELL is csh
-bash: csh: command not found
== SHELL is tcsh
-bash: tcsh: command not found
== SHELL is zsh
/tmp/hello:/usr/share/Modules/modulefiles:/etc/modulefiles:/usr/share/modulefiles:/opt/apps/modulefiles
== SHELL is ksh
-bash: ksh: command not found
== SHELL is bash
/tmp/hello:/usr/share/Modules/modulefiles:/etc/modulefiles:/usr/share/modulefiles:/opt/apps/modulefiles
== SHELL is bash -l
/tmp/hello:/usr/share/Modules/modulefiles:/etc/modulefiles:/usr/share/modulefiles:/opt/apps/modulefiles

```
Edge scenarios for when:
1. Scl-utils have a dependency on environment-modules and it will install environment-modules if install_scl_utils: true regardless of install_environment_modules as otherwise dnf will uninstall scl-utils. While image build, a warning stating this is issued in Packer VM.
2. Ompi has a dependency on Lmod, so whenever install_ompi is set to true, Lmod will be installed regardless of install_lmod flag as otherwise we cannot access ompi. While image build, a warning stating this is also issued in Packer VM.

The aforementioned warnings issued for visibility :
```
Jul 27 09:23:21 packer-48dde2 : Metadata key("startup-script"), command("/bin/bash"): TASK [Warn on OMPI and Lmod dependencies] **************************************
Jul 27 09:23:21 packer-48dde2 : Metadata key("startup-script"), command("/bin/bash"): ok: [localhost] => {
Jul 27 09:23:21 packer-48dde2 google_metadata_script_runner[2437]: Metadata key("startup-script"), command("/bin/bash"):     "msg": "WARNING: install_ompi is true but install_lmod is false. OpenMPI requires Lmod to load properly. Automatically enabling install_lmod."
Jul 27 09:23:21 packer-48dde2  Metadata key("startup-script"), command("/bin/bash"): }
Jul 27 09:23:21 packer-48dde2 : Metadata key("startup-script"), command("/bin/bash"):
Jul 27 09:23:21 packer-48dde2 : Metadata key("startup-script"), command("/bin/bash"): TASK [Warn if scl-utils installs env-modules implicitly] ***********************
Jul 27 09:23:21 packer-48dde2 : Metadata key("startup-script"), command("/bin/bash"): ok: [localhost] => {
Jul 27 09:23:21 packer-48dde2 : Metadata key("startup-script"), command("/bin/bash"):     "msg": "WARNING: install_environment_modules is false but install_scl_utils is true. scl-utils will install environment-modules by default."

```
