### PR TITLE
updated the TCPXO version in the  prolog script

### DIFF
--- a/tools/prologs-epilogs/receive-data-path-manager-mega
+++ b/tools/prologs-epilogs/receive-data-path-manager-mega
@@ -28,8 +28,8 @@ fi
 # ensure that dmabuf-import-helper is loaded
 modprobe import-helper
 
-NCCL_PLUGIN_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15
-RXDM_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
+NCCL_PLUGIN_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.17
+RXDM_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.23
 RXDM_CONTAINER=receive-datapath-manager-"${SLURM_JOB_ID}"
 if [[ ${SLURM_SCRIPT_CONTEXT} == "prolog_slurmd" ]]; then
 	docker container list --filter "name=receive-datapath-manager-*" --quiet | xargs --no-run-if-empty docker container stop


### PR DESCRIPTION
Updating the prolog script to support TCPXO v1.0.17.
NCCL tests successful -- avg busbw: 145.315 GB/s