### PR TITLE
feat: make slurm installation optional

### DIFF
--- a/ansible/docker-playbook.yml
+++ b/ansible/docker-playbook.yml
@@ -53,6 +53,7 @@
     install_gcsfuse: true
     install_pmix: true
     install_pyxis: true
+    install_slurm: true
 
   pre_tasks:
   - name: Minimum Ansible Version Check
@@ -109,6 +110,12 @@
       that: ansible_distribution_version is version('20.04', '==') or ansible_distribution_version is version('22.04', '==') or ansible_distribution_version is version('24.04', '==')
       fail_msg: |
         When building Slurm-GCP on Ubuntu, use release 20.04/22.04/24.04
+  - name: Check Pyxis Install Options
+    when: install_pyxis
+    ansible.builtin.assert:
+      that: install_slurm
+      fail_msg: |
+        install_slurm must be true when install_pyxis is true
 
   roles:
   - motd
@@ -137,10 +144,11 @@
   - role: slurm
     vars:
       handle_services: false
-  - slurmcmd
+    when: install_slurm
+  - role: slurmcmd
+    when: install_slurm
   - role: pyxis
-    when:
-    - install_pyxis
+    when: install_pyxis
   - role: ompi
     when: install_ompi
   - role: lustre

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -58,6 +58,7 @@
     install_lustre: true
     install_managed_lustre: false
     install_munge: true
+    install_slurm: true
     slurm_patch_files: []
     install_gcsfuse: true
     install_gcsfuse_spank: false
@@ -131,6 +132,18 @@
       that: (ansible_distribution == "Ubuntu" and (ansible_distribution_version is version('20.04', '==') or ansible_distribution_version is version('22.04', '==') or ansible_distribution_version is version('24.04', '=='))) or (ansible_distribution == "Rocky" and (ansible_distribution_major_version is version('8', '==') or ansible_distribution_major_version is version('9', '==')))
       fail_msg: |
         Managed Lustre is only compatible with Rocky 8, Rocky 9, Ubuntu 20.04, Ubuntu 22.04, and Ubuntu 24.04
+  - name: Check Pyxis Install Options
+    when: install_pyxis
+    ansible.builtin.assert:
+      that: install_slurm
+      fail_msg: |
+        install_slurm must be true when install_pyxis is true
+  - name: Check GCSFuse SPANK Install Options
+    when: install_gcsfuse_spank
+    ansible.builtin.assert:
+      that: install_slurm
+      fail_msg: |
+        install_slurm must be true when install_gcsfuse_spank is true
   - name: Freeze kernel before running playbook
     ansible.builtin.command:
       argv:
@@ -168,11 +181,12 @@
   - mariadb
   - libjwt
   - lmod
-  - slurm
-  - slurmcmd
+  - role: slurm
+    when: install_slurm
+  - role: slurmcmd
+    when: install_slurm
   - role: pyxis
-    when:
-    - install_pyxis
+    when: install_pyxis
   - role: ompi
     when: install_ompi
   - role: lustre

--- a/ansible/roles/pyxis/meta/main.yml
+++ b/ansible/roles/pyxis/meta/main.yml
@@ -16,4 +16,3 @@
 dependencies:
 - role: common
 - role: enroot
-- role: slurm

--- a/ansible/roles/slurmcmd/meta/main.yml
+++ b/ansible/roles/slurmcmd/meta/main.yml
@@ -13,7 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-dependencies:
-- role: slurm
-  vars:
-    handle_services: false
+dependencies: []

--- a/tools/prologs-epilogs/receive-data-path-manager-mega
+++ b/tools/prologs-epilogs/receive-data-path-manager-mega
@@ -28,8 +28,8 @@ fi
 # ensure that dmabuf-import-helper is loaded
 modprobe import-helper
 
-NCCL_PLUGIN_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15
-RXDM_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
+NCCL_PLUGIN_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.17
+RXDM_IMAGE=us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.23
 RXDM_CONTAINER=receive-datapath-manager-"${SLURM_JOB_ID}"
 if [[ ${SLURM_SCRIPT_CONTEXT} == "prolog_slurmd" ]]; then
 	docker container list --filter "name=receive-datapath-manager-*" --quiet | xargs --no-run-if-empty docker container stop


### PR DESCRIPTION
Make slurm installation optional via the install_slurm variable so it can be skipped when building images that don't need Slurm pre-installed.