### PR TITLE
Allow external patches

### DIFF
--- a/ansible/roles/slurm/defaults/main.yml
+++ b/ansible/roles/slurm/defaults/main.yml
@@ -16,7 +16,7 @@
 slurm_git_url: https://github.com/SchedMD/slurm.git
 slurm_version: 26.05.0
 slurm_tar_baseurl: https://github.com/SchedMD/slurm/releases/download/slurm-{{ slurm_version | replace('.', '-') }}-1
-slurm_patch_files: ["tpu-2605.patch"]
+slurm_patch_files: ["patches/tpu-2605.patch"]
 
 slurm_paths:
   install: '{{paths.install}}'

--- a/ansible/roles/slurm/tasks/install.yml
+++ b/ansible/roles/slurm/tasks/install.yml
@@ -47,11 +47,11 @@
 
 - name: Apply Slurm patches
   ansible.posix.patch:
-    src: ../files/patches/{{ item }}
+    src: '{{ item }}'
     basedir: '{{slurm_paths.src}}'
     strip: 1
   loop: "{{ slurm_patch_files }}"
-  ignore_errors: true
+  ignore_errors: false
   when: slurm_patch_files != []
 
 # For any build dependencies added by patches


### PR DESCRIPTION
After appling this patch, all patches in `files/patches/{filename}` needs to be referenced as `patches/{filename}` instead of `{filename}.
