### PR TITLE
Allow external patches

### DIFF
--- a/ansible/roles/slurm/tasks/install.yml
+++ b/ansible/roles/slurm/tasks/install.yml
@@ -47,11 +47,11 @@
 
 - name: Apply Slurm patches
   ansible.posix.patch:
-    src: ../files/patches/{{ item }}
+    src: '{{ item }}'
     basedir: '{{slurm_paths.src}}'
     strip: 1
   loop: "{{ slurm_patch_files }}"
-  ignore_errors: true
+  ignore_errors: false
   when: slurm_patch_files != []
 
 - name: Configure


### PR DESCRIPTION
Removes restriction on the patch needing to be present in patch file path.